### PR TITLE
CASSANDRA-15964 cleanup dead links

### DIFF
--- a/src/community.md
+++ b/src/community.md
@@ -28,8 +28,10 @@ Discussion and questions on Cassandra's usage and development happens mainly on 
 
 We have recently moved to the ASF Slack organization for all chat.  Please [sign up for an account](https://s.apache.org/slack-invite) to participate.
 
-* `#cassandra` - for user questions and general discussions.
-* `#cassandra-dev` - strictly for questions or discussions related to Cassandra development.
+* `#cassandra` - for user questions and general discussions
+* `#cassandra-dev` - strictly for questions or discussions related to Cassandra development
+* `#cassandra-builds` - results of automated test builds
+* `#cassandra-builds-patches` - results of patch test builds
 
 ### Stack Overflow
 

--- a/src/community.md
+++ b/src/community.md
@@ -31,20 +31,10 @@ We have recently moved to the ASF Slack organization for all chat.  Please [sign
 * `#cassandra` - for user questions and general discussions.
 * `#cassandra-dev` - strictly for questions or discussions related to Cassandra development.
 
-#### IRC<a name="irc"></a>
-
-*Note*: Most discussion has been moved to the above Slack channels.  
-
-* `#cassandra-dev` - strictly for questions or discussions related to Cassandra development.
-* `#cassandra-builds` - results of automated test builds.
-
-Communication on the `#cassandra-dev` channel is [publicly archived](http://wilderness.apache.org/channels/#logs-#cassandra-dev).
-
 ### Stack Overflow
 
 You can also check the [Q&A about using Cassandra](http://stackoverflow.com/questions/tagged/cassandra) on Stack
 Overflow.
-
 
 ### Books and publications
 

--- a/src/index.html
+++ b/src/index.html
@@ -91,7 +91,7 @@ is_homepage: true
       <div class="col-md-3 col-sm-3 feature-item">
         <h4>Durable</h4>
         <p>
-        Cassandra is <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/Durability">suitable for applications that can't afford to lose data</a>,
+        Cassandra is <a href="https://cassandra.apache.org/doc/latest/architecture/guarantees.html#durability1">suitable for applications that can't afford to lose data</a>,
         even when an entire data center goes down.
         </p>
       </div>
@@ -100,8 +100,8 @@ is_homepage: true
         <h4>You're in control</h4>
         <p>
         Choose between synchronous or asynchronous replication for each update. Highly available asynchronous operations are
-        optimized with features like <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/HintedHandoff">Hinted Handoff</a> and
-        <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/ReadRepair">Read Repair</a>.</p>
+        optimized with features like <a href="https://cassandra.apache.org/doc/latest/operating/hints.html">Hinted Handoff</a> and
+        <a href="https://cassandra.apache.org/doc/latest/operating/read_repair.html">Read Repair</a>.</p>
         </p>
       </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -23,19 +23,32 @@ is_homepage: true
         <p>
         Cassandra is in use at
         <a href="https://www.dataversity.net/case-study-cassandra-meets-call-of-duty/">Activision</a>,
+	<a href="https://www.techrepublic.com/article/apples-secret-nosql-sauce-includes-a-hefty-dose-of-cassandra/">Apple</a>,
+	<a href="https://www.youtube.com/watch?v=5jKZUnkhB50">BazaarVoice</a>,
+	<a href="https://www.slideshare.net/joelcrabb/cassandra-and-riak-at-bestbuycom">Best Buy</a>,
+	CERN,
         <a href="http://www.slideshare.net/daveconnors/cassandra-puppet-scaling-data-at-15-per-month">Constant Contact</a>,
-
         <a href="http://www.slideshare.net/planetcassandra/nyc-tech-day-using-cassandra-for-dvr-scheduling-at-comcast">Comcast</a>,
         <a href="http://www.slideshare.net/jaykumarpatel/cassandra-at-ebay-13920376">eBay</a>,
-
-
-	<a href="https://www.datastax.com/blog/2020/04/accelerate-rewind-how-instagram-uses-cassandra-operate-global-scale-2">Instagram</a>,
-
+	Fidelity,
+	Github,	
+	<a href="https://www.nexttv.com/news/hulu-scales-user-database-apache-cassandra-133429">Hulu</a>,
+	<a href="https://ithome.com.tw/video/103028">ING</a>,
+	<a href="https://instagram-engineering.com/open-sourcing-a-10x-reduction-in-apache-cassandra-tail-latency-d64f86b43589">Instagram</a>,
 	<a href="https://www.datastax.com/resources/video/datastax-accelerate-2019-managing-400-billion-requests-zero-downtime-turbotax">Intuit</a>, 
-
+	<a href="https://www.slideshare.net/planetcassandra/apache-cassandra-at-macys">Macy's™</a>,
+	<a href="https://diginomica.com/macquarie-banks-on-customer-appetite-for-a-spotify-like-experience">Macquarie Bank</a>,
+	Microsoft,
+	McDonalds,
 	<a href="https://www.slideshare.net/VinayKumarChella/how-netflix-manages-petabyte-scale-apache-cassandra-in-the-cloud">Netflix</a>, 
-
-        and  thousands of other companies that have large, active data sets.</p>
+	<a href="https://www.slideshare.net/planetcassandra/michael-laing-nyt-developers1">New York Times</a>,
+	Outbrain,
+	Pearson Education,
+	<a href="https://www.slideshare.net/OliverLockwood1/apache-cassandra-building-a-production-app-on-an-eventuallyconsistent-db">Sky</a>,
+	<a href="https://engineering.atspotify.com/2015/01/09/personalization-at-spotify-using-cassandra/">Spotify</a>,
+	<a href="http://highscalability.com/blog/2016/9/28/how-uber-manages-a-million-writes-per-second-using-mesos-and.html">Uber</a>,
+	<a href="https://medium.com/walmartlabs/how-we-build-a-robust-analytics-platform-using-spark-kafka-and-cassandra-lambda-architecture-70c2d1bc8981">Walmart</a>,
+        and  thousands of other companies that have large, active data sets. In fact, Cassandra is used by 40% of the Fortune 100.</p>
       </div>
 
       <div class="col-md-2 col-sm-2 feature-item">
@@ -51,7 +64,7 @@ is_homepage: true
         <p>
         Cassandra <a href="http://vldb.org/pvldb/vol5/p1724_tilmannrabl_vldb2012.pdf">consistently</a>
         <a href="http://www.datastax.com/resources/whitepapers/benchmarking-top-nosql-databases">outperforms</a> popular
-        NoSQL alternatives in benchmarks and <a href="http://blog.markedup.com/2013/02/cassandra-hive-and-hadoop-how-we-picked-our-analytics-stack/">real applications</a>,
+        NoSQL alternatives in benchmarks and real applications,
         primarily because of <a href="https://www.datastax.com/blog/2013/01/2012-review-performance">fundamental architectural choices</a>.
         </p>
       </div>
@@ -78,7 +91,7 @@ is_homepage: true
       <div class="col-md-3 col-sm-3 feature-item">
         <h4>Durable</h4>
         <p>
-        Cassandra is <a href="http://wiki.apache.org/cassandra/Durability">suitable for applications that can't afford to lose data</a>,
+        Cassandra is <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/Durability">suitable for applications that can't afford to lose data</a>,
         even when an entire data center goes down.
         </p>
       </div>
@@ -87,8 +100,8 @@ is_homepage: true
         <h4>You're in control</h4>
         <p>
         Choose between synchronous or asynchronous replication for each update. Highly available asynchronous operations are
-        optimized with features like <a href="http://wiki.apache.org/cassandra/HintedHandoff">Hinted Handoff</a> and
-        <a href="http://wiki.apache.org/cassandra/ReadRepair">Read Repair</a>.</p>
+        optimized with features like <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/HintedHandoff">Hinted Handoff</a> and
+        <a href="https://cwiki.apache.org/confluence/display/CASSANDRA2/ReadRepair">Read Repair</a>.</p>
         </p>
       </div>
 
@@ -103,7 +116,7 @@ is_homepage: true
       <div class="col-md-3 col-sm-3 feature-item">
         <h4>Professionally Supported</h4>
         <p>
-          Cassandra support contracts and services are available from <a href="http://wiki.apache.org/cassandra/ThirdPartySupport">third parties</a>.
+          Cassandra support contracts and services are available from <a href="https://cassandra.apache.org/third-party/">third parties</a>.
         </p>
       </div>
     </div><!-- /.feature-list -->

--- a/src/third-party.md
+++ b/src/third-party.md
@@ -36,14 +36,15 @@ Snap it into your existing workflows with the click of a button, automate away t
 
 ### Cassandra Kubernetes operators
 
-* [DataStax cass-operator](https://github.com/datastax/cass-operator): The DataStax Kubernetes Operator for Apache Cassandra
 * [D2iQ Cassandra Kudo Operator](https://github.com/mesosphere/kudo-cassandra-operator): The KUDO Cassandra Operator makes it easy to deploy and manage Apache Cassandra on Kubernetes.
+* [DataStax cass-operator](https://github.com/datastax/cass-operator): The DataStax Kubernetes Operator for Apache Cassandra
 * [Instaclustr cassandra-operator](https://github.com/instaclustr/cassandra-operator): The Cassandra operator manages Cassandra clusters deployed to Kubernetes and automates tasks related to operating a Cassandra cluster.
 * [Orange CassKop](https://orange-opensource.github.io/casskop/): The Orange Cassandra operator is a Kubernetes operator to automate provisioning, management, autoscaling and operations of Apache Cassandra clusters deployed to K8s.
 * [Sky Cassandra Operator](https://github.com/sky-uk/cassandra-operator): The Sky Cassandra Operator is a Kubernetes operator that manages Cassandra clusters inside Kubernetes.
 
 ### Cassandra management sidecars
 
+* [Apache Cassandra cassandra-sidecar](https://github.com/apache/cassandra-sidecar): Sidecar for the highly scalable Apache Cassandra database, built as part of the Apache Cassandra project.
 * [DataStax Management API for Apache Cassandra](https://github.com/datastax/management-api-for-apache-cassandra): RESTful / Secure Management Sidecar for Apache Cassandra
 * [DataStax Spring Boot](https://github.com/datastax/spring-boot): Spring Boot extension
 * [Instaclustr cassandra-sidecar](https://github.com/instaclustr/cassandra-sidecar): This repository is home of a sidecar for Apache Cassandra database. Sidecar is meant to be run alongside of Cassandra instance and sidecar talks to Cassandra via JMX.
@@ -77,3 +78,10 @@ Snap it into your existing workflows with the click of a button, automate away t
 #### Apache Pulsar
 
 * [Pulsar Sink Connector](https://pulsar.apache.org/docs/en/io-quickstart/#connect-pulsar-to-cassandra): The Pulsar Cassandra Sink connector is used to write messages to a Cassandra Cluster.
+
+#### Professional Support
+
+* [DataStax Luna](https://luna.datastax.com/), [DataStax Premium Support](https://www.datastax.com/services/support/premium-support), [DataStax Professional Services](https://www.datastax.com/services/professional-services)
+* [Instacluster](https://www.instaclustr.com/services/)
+* [Open Credo](https://opencredo.com/about-us/)
+


### PR DESCRIPTION
Additional edits to the website pages to clean up dead links, add additional companies using Cassandra, and redirect Support link to third-party page.