### PR TITLE
CASSANDRA-16727 - Fixes License text problem in website

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,4 +1,20 @@
 <!DOCTYPE html>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. -->
+
 <html>
   {% include head.html %}
   <body>


### PR DESCRIPTION
Added License text comment to default.hml so that all pages will display with a license comment

Tested via desktop jekyll build