### PR TITLE
Update download.adoc

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -87,7 +87,6 @@ Older (unsupported) versions of Cassandra are archived https://archive.apache.or
 
 [discrete]
 === Installation from Debian packages
-You'll need to have Docker Desktop for Mac, Docker Desktop for Windows, or similar software installed on your computer.
 
 * For the `<release series>` specify the major version number, without dot, and with an appended x.
 * The latest `<release series>` is `40x`.


### PR DESCRIPTION
I saw there is currently a sentence in the Debian section of the downloads page that mentions Docker, which I don't think needs to be there!?

This just removes that Docker text .