### PR TITLE
CASSANDRA-16980: Added September 2021 blog post on ApacheCon 2021

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog.adoc
+++ b/site-content/source/modules/ROOT/pages/blog.adoc
@@ -14,6 +14,31 @@ NOTES FOR CONTENT CREATORS
 [openblock,card-header]
 ------
 [discrete]
+=== Join Cassandra at Apachecon 2021
+[discrete]
+==== August 27, 2021
+------
+[openblock,card-content]
+------
+Register to attend ApacheCon 2021 for a packed series of presentations on the new features in development for Apache Cassandra, along with best practices for CI & testing, and cutting-edge use cases. The BoF event at the end of the day includes a deep dive into Apache Cassandra 4.0 and cocktail-making.
+
+[openblock,card-btn card-btn--blog]
+--------
+
+[.btn.btn--alt]
+xref:blog/Join-Cassandra-at-ApacheCon-2021.adoc[Read More]
+--------
+
+------
+----
+//end card
+
+//start card
+[openblock,card shadow relative test]
+----
+[openblock,card-header]
+------
+[discrete]
 === Cassandra on Kubernetes: A Beginner's Guide 
 [discrete]
 ==== August 27, 2021

--- a/site-content/source/modules/ROOT/pages/blog/Join-Cassandra-at-ApacheCon-2021.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Join-Cassandra-at-ApacheCon-2021.adoc
@@ -1,0 +1,36 @@
+= Join Cassandra at ApacheCon 2021
+:page-layout: single-post
+:page-role: blog-post
+:page-post-date: September 20, 2020
+:page-post-author: The Apache Cassandra Community
+:description: The Apache Cassandra Community
+:keywords: 
+
+With the release of https://cassandra.apache.org/_/blog/Apache-Cassandra-4.0-is-Here.html[Apache Cassandra v4.0], the project has much to celebrate this year, but the community is moving forward with new features in development. At this year’s virtual ApacheCon, Apache Cassandra will be running a https://www.apachecon.com/acah2021/tracks/cassandra.html[breakout track,window=_blank] from Tuesday, 21 September to Wednesday, 22 September. 
+
+During the track, you will learn about proposed features that will see an even more secure Cassandra by default, improve testing patterns (with the use of contract testing, service tests, and singleton decoupling), and evolve transactions by improving Cassandra’s Paxos implementation.
+
+The full https://www.apachecon.com/acah2021/tracks/cassandra.html[Cassandra track schedule is available here,window=_blank] and those interested in participating can register on the ApacheCon site https://apachecon.com/acah2021/register.html[here,window=_blank]. The event will start at 15:00 UTC.
+
+The two-day event with 13 talks includes:
+
+* *The Future of Security for CQLSH* — Arturo Hinojosa, Derek Chen-Becker, Amazon Keyspaces, AWS
+* *Making Cassandra Faster in Cloud-native architecture* — Subrata Ashe, Salesforce
+* *Cassandra powered workflows to automate at scale* — Maciej Swiderski, OpenEnterprise
+* *Fuzz Testing and Verification of Apache Cassandra with "Harry"* — Alex Petrov, Apache Cassandra committer.
+* *The trials and tribulations of a CI pipeline on Apache Infra* — Mick Semb Wever, The Last Pickle & DataStax
+* *Improving Testing Patterns for Apache Cassandra* — Brian Houser, Arturo Hinojosa, Amazon Keyspaces, AWS
+* *Evolving Transactions in Apache Cassandra* — Benedict Elliot Smith, Apache Cassandra committer
+* *Designing Keys for NOSQL solutions* — Nikolai Kolesnikov, AWS
+* *Cassandra Data Migration with Dual Write Proxy* — German Eichberger, Microsoft Azure Data & AI
+* *Modeling Financial Data In Cassandra To Serve Real Time And Batch Workloads At Same Time* — Gokul Prabagaren, Capital One
+* *How Netflix Provisions Optimal Cloud Deployments of Cassandra* — Joey Lynch, Netflix
+* *Stargate.io, An OSS API Layer for your Cassandra* — Cedrick Lunven, DataStax
+* *Cassandra for giant 3D tables* — David North, CoreFiling
+
+At the end of the first track day on Tuesday, we’ll be hosting a Birds of Feather (BoF) session
+from 2030 to 2110 UTC with Melissa Logan hosting a discussion about Cassandra 4.0 between Patrick McFadin and Aaron Ploetz. We’ll dig deeper into the benefits, upgrade, and more. Bring your questions to this interactive discussion!
+
+We will also have a fun cocktail-making session in the last 15 minutes. Those who want to take part, please take a look at the https://docs.google.com/document/d/1kb57J5z6i4-NztorRlBMQB9DOpxekgqqTl7J5HiS6-c/edit#[list of ingredients for three cocktail/mocktail choices here,window=_blank].
+
+Join us for a packed Cassandra track this year!


### PR DESCRIPTION
- Blog post is titled "Join Cassandra at Apachecon 2021" about ApacheCon 2021
- Modified blog index page