### PR TITLE
fix sample command does not work

### DIFF
--- a/site-content/source/modules/ROOT/pages/quickstart.adoc
+++ b/site-content/source/modules/ROOT/pages/quickstart.adoc
@@ -90,7 +90,7 @@ The CQL shell, or cqlsh, is one tool to use in interacting with the database. We
 [source]
 --
 
-docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 nuvo/docker-cqlsh 
+docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 -e CQLVERSION=3.4.5 nuvo/docker-cqlsh 
 
 --
 Note: The cassandra server itself (the first docker run command you ran) takes a few seconds to start up. The above command will throw an error if the server hasn't finished its init sequence yet, so give it a few seconds to spin up.


### PR DESCRIPTION
the docker image cassandra:latest does not support cqlversion 3.4.4 now which is the default cqlversion of nuvo/docker-cqlsh:latest