### PR TITLE
CASSANDRA-17060: Added October 2021 blog post on What the Future Holds for Apache Cassandra

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog.adoc
+++ b/site-content/source/modules/ROOT/pages/blog.adoc
@@ -14,6 +14,31 @@ NOTES FOR CONTENT CREATORS
 [openblock,card-header]
 ------
 [discrete]
+=== What the Future Holds for Apache Cassandra
+[discrete]
+==== October 26, 2021
+------
+[openblock,card-content]
+------
+The release of Apache Cassandra 4.0 has opened the floodgates to new feature proposals. Many feature ideas have been approved and are in development such as a cluster and code action simulator and support for general-purpose transaction support while others, such as Storage Attached Indexing, are being discussed.
+
+[openblock,card-btn card-btn--blog]
+--------
+
+[.btn.btn--alt]
+xref:blog/What-the-Future-Holds-for-Apache-Cassandra.adoc[Read More]
+--------
+
+------
+----
+//end card
+
+//start card
+[openblock,card shadow relative test]
+----
+[openblock,card-header]
+------
+[discrete]
 === Apache Cassandra Changelog #10
 [discrete]
 ==== October 5, 2021

--- a/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-10-October-2021.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-10-October-2021.adoc
@@ -12,7 +12,7 @@ Our monthly roundup of key activities and knowledge to keep the community inform
 == Release Notes
 === Released
 
-The latest release of Apache Cassandra is https://www.apache.org/dyn/closer.lua/cassandra/4.0.1[4.0.1,window=_blank] (https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.asc[pgp,window=_blank], https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha256[sha256,window=_blank], and https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha512[sha512). This is a rapid release to fix a https://issues.apache.org/jira/browse/CASSANDRA-16877[critical bug,window=_blank] in Gossip on large clusters. Please read the https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=refs/tags/cassandra-4.0.1[release notes,window=_blank] and let us know if you encounter any problems.
+The latest release of Apache Cassandra is https://www.apache.org/dyn/closer.lua/cassandra/4.0.1[4.0.1,window=_blank] (https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.asc[pgp,window=_blank], https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha256[sha256,window=_blank], and https://archive.apache.org/dist/cassandra/4.0.1/apache-cassandra-4.0.1-bin.tar.gz.sha512[sha512,window=_blank]). This is a rapid release to fix a https://issues.apache.org/jira/browse/CASSANDRA-16877[critical bug,window=_blank] in Gossip on large clusters. Please read the https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=refs/tags/cassandra-4.0.1[release notes,window=_blank] and let us know if you encounter any problems.
 
 Note: As the docs are not yet updated, the bintray location for Debian users is replaced with the https://apache.jfrog.io/artifactory/cassandra/[ASF's JFrog Artifactory location,window=_blank].
 
@@ -24,9 +24,9 @@ To stay up-to-date, we recommend joining the Cassandra xref:community.adoc#join-
 
 _Updates on Cassandra Enhancement Proposals (CEPs), how to contribute, and other community activities._
 
-_Are you new to the project? We have established a https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=484.[New Release tracking Kanboard,window=_blank] and a "https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=484&quickFilter=2162&quickFilter=2160[Starter Tickets,window=_blank]" quick label that corresponds to our Low Hanging Fruit status. Any of these tickets should be of appropriate complexity for someone new to the project to tackle._
+_Are you new to the project? We have established a https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=484[New Release tracking Kanboard,window=_blank] and a https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=484&quickFilter=2162&quickFilter=2160["Starter Tickets",window=_blank] quick label that corresponds to our Low Hanging Fruit status. Any of these tickets should be of appropriate complexity for someone new to the project to tackle._
 
-Read PMC member Josh McKenzie’s https://lists.apache.org/list.html?dev@cassandra.apache.org:2021-9[bi-weekly update,window=_blank] for ongoing discussions and the latest on ticket progress.
+Read PMC member Josh McKenzie’s https://lists.apache.org/list.html?\dev@cassandra.apache.org:2021-9[bi-weekly update,window=_blank] for ongoing discussions and the latest on ticket progress.
 
 === Added
 
@@ -50,7 +50,7 @@ We have a formal proposal from Brian Houser for https://lists.apache.org/thread.
 
 === Discussed
 
-As always, there are lots of discussions going on. Ekaterina Dimitrova started a good conversation on https://lists.apache.org/thread.html/r507be1624a568765f9d5ec5f6b561885129d0aaeb982e9bd9bf5e01b%40%3Cdev.cassandra.apache.org%3E[standardizing configuration and JVM parameters,window=_blank] and drove a discussion on https://lists.apache.org/list.html?dev@cassandra.apache.org:2021-8[JDK 17 support,window=_blank], which is now being developed. We are also defining https://lists.apache.org/list.html?dev@cassandra.apache.org:2021-9[which code changes target which types of release,window=_blank], deciding when a minor becomes a major, for example, and when feature flags should be used. Josh McKenzie is putting together a wiki on this, and we will run a blog piece on the outcomes from the discussion in the hope it helps other open source projects facing similar questions.
+As always, there are lots of discussions going on. Ekaterina Dimitrova started a good conversation on https://lists.apache.org/thread.html/r507be1624a568765f9d5ec5f6b561885129d0aaeb982e9bd9bf5e01b%40%3Cdev.cassandra.apache.org%3E[standardizing configuration and JVM parameters,window=_blank] and drove a discussion on https://lists.apache.org/list.html?\dev@cassandra.apache.org:2021-8[JDK 17 support,window=_blank], which is now being developed. We are also defining https://lists.apache.org/list.html?\dev@cassandra.apache.org:2021-9[which code changes target which types of release,window=_blank], deciding when a minor becomes a major, for example, and when feature flags should be used. Josh McKenzie is putting together a wiki on this, and we will run a blog piece on the outcomes from the discussion in the hope it helps other open source projects facing similar questions.
 
 === Added
 

--- a/site-content/source/modules/ROOT/pages/blog/What-the-Future-Holds-for-Apache-Cassandra.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/What-the-Future-Holds-for-Apache-Cassandra.adoc
@@ -1,0 +1,32 @@
+= What the Future Holds for Apache Cassandra
+:page-layout: single-post
+:page-role: blog-post
+:page-post-date: October 26, 2021
+:page-post-author: The Apache Cassandra Community
+:description: The Apache Cassandra Community
+:keywords: 
+
+Prior to the release of Apache Cassandra 4.0, all new features were https://lists.apache.org/thread.html/18c76129a4fe6785a51dad7500e04ee13a407a7f7ac5c8f9a3d83c87%40%3Cdev.cassandra.apache.org%3E[frozen,window=_blank] to enable project committers to focus on making 4.0 the best-tested and most reliable major release right out of the gate. 
+
+The community has invested in cutting-edge methodologies that were used at scale to exercise edge cases in the largest Cassandra clusters, and after extensive testing and validation, 4.0 GA was released on 26 July 2021.
+
+With a quality baseline for releases in place for future versions, the project is again accepting proposals for new features. The Cassandra Enhancement Process (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=95652201[CEP,window=_blank]), similar to some other Apache projects, was established last year and now makes CEPs the preferred route for broad or disruptive changes to the Cassandra codebase. This structured approach opens the door wide to exploring, discussing, and developing new and exciting major features for Cassandra (see https://lists.apache.org/list.html?dev@cassandra.apache.org:gte=1d:CEP[recent CEP discussions here,window=_blank]).
+
+*A host of new enhancements*
+Already we have seen CEPs approved and in development, such as:
+
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-10%3A+Cluster+and+Code+Simulations[Cluster & code action simulator,window=_blank] - a facility for simulating operations on clusters that enables repeatable but pseudo-random exploration of state space and correctness testing. This will bolster the already formidable testing capabilities the Cassandra community offers and represents a true advancement in the state-of-the-art for distributed systems testing.
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-13%3A+Denylisting+partitions[Denylisting partitions,window=_blank] - when operating Cassandra in production, reading certain partition keys can cause undesirable effects on the entire node or within the cluster. This denylisting feature is another critical tool in the operator toolbox to reduce the impact of unexpected or unhealthy client reads and writes on specific partitions. This feature will also prevent DDOS attacks where a hacker uses partition keys maliciously.
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-15%3A+General+Purpose+Transactions[General-purpose transactions,window=_blank] - a popular feature in community discussion which has been quickly approved, this CEP, when implemented, will be a major feature for many users as it will deliver the first-ever database that supports general-purpose transactions without the recognized trade-offs seen in other databases, such as scalability bottlenecks or the lack of strong consistency guarantees.
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-11%3A+Pluggable+memtable+implementations[Memtable pluggable memtable storage,window=_blank] - this is a CEP with potentially the broadest impact for more advanced use cases such as persistent memory. This feature is also a crucial first step in exploring using alternative storage engines within Cassandra, optimized for specific workloads. Instagram has already shown early promise with this idea by adding RocksDB as a storage engine.
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-14%3A+Paxos+Improvements[Paxos improvements,window=_blank] - a feature that builds on the cluster simulation CEP and improves the performance of lightweight transactions (LWTs). This type of transaction is used to guarantee that the data most recently written is considered before a read, which, in turn, ensures a high level of consistency for any decisions you want to make on data and allows linearizable access by concurrent users. The primary benefit of the Paxos improvements will be a huge performance boost to operations in a wide area setting while also benefiting correctness of LWTs across a range of scenarios such as range movements.
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-16%3A+Auth+Plugin+Support+for+CQLSH[Auth Plugin Support for CQLSH,window=_blank] - CQLSH, the included CLI tool, is important and useful, but, unfortunately, lacks the same support for different authentication methods. This will allow anyone using third-party-provided plugins like LDAP, Kerberos, and Sigv4 to be able to continue to use CQSLH.
+
+Many other CEPs are being proposed and nearing a vote for approval, such as:
+* https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-7%3A+Storage+Attached+Index[Storage Attached Indexing (SAI),window=_blank] - this is another CEP nearing a vote, which is designed to replace the original secondary indexing. This will enable users to index multiple columns on the same table without suffering scaling problems, especially at write time.
+
+While there are proposals to add some headline-grabbing features, such as JOIN support to Apache Cassandra, some features confirm work that has already been undertaken. For example, the experimental flag for Java 11 has been removed and is now officially supported, while development to support Java 17 is in full swing and Cassandra will take advantage of the rapidly evolving innovations in Java garbage collection. As we’ve already seen in https://jaxenter.com/apache-cassandra-java-174575.html[performance tests for JDK16,window=_blank], Z Garbage Collection (ZGC) is now delivering submillisecond pause times, and we expect more significant gains in the near future.
+
+The latest release of Apache Cassandra is 4.0.1, which was rapidly pushed out to deal with a https://issues.apache.org/jira/browse/CASSANDRA-16877[bug,window=_blank] in Gossip on large clusters. 
+
+Apache Cassandra is moving fast and gathering rich features for a targeted yearly release cadence. Subscribe to the xref:community.adoc#join-the-conversation[mailing list] to stay up to date with the latest developments.

--- a/site-content/source/modules/ROOT/pages/blog/What-the-Future-Holds-for-Apache-Cassandra.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/What-the-Future-Holds-for-Apache-Cassandra.adoc
@@ -10,9 +10,10 @@ Prior to the release of Apache Cassandra 4.0, all new features were https://list
 
 The community has invested in cutting-edge methodologies that were used at scale to exercise edge cases in the largest Cassandra clusters, and after extensive testing and validation, 4.0 GA was released on 26 July 2021.
 
-With a quality baseline for releases in place for future versions, the project is again accepting proposals for new features. The Cassandra Enhancement Process (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=95652201[CEP,window=_blank]), similar to some other Apache projects, was established last year and now makes CEPs the preferred route for broad or disruptive changes to the Cassandra codebase. This structured approach opens the door wide to exploring, discussing, and developing new and exciting major features for Cassandra (see https://lists.apache.org/list.html?dev@cassandra.apache.org:gte=1d:CEP[recent CEP discussions here,window=_blank]).
+With a quality baseline for releases in place for future versions, the project is again accepting proposals for new features. The Cassandra Enhancement Process (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=95652201[CEP,window=_blank]), similar to some other Apache projects, was established last year and now makes CEPs the preferred route for broad or disruptive changes to the Cassandra codebase. This structured approach opens the door wide to exploring, discussing, and developing new and exciting major features for Cassandra (see https://lists.apache.org/list.html?\dev@cassandra.apache.org:gte=1d:CEP[recent CEP discussions here,window=_blank]).
 
 *A host of new enhancements*
+
 Already we have seen CEPs approved and in development, such as:
 
 * https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-10%3A+Cluster+and+Code+Simulations[Cluster & code action simulator,window=_blank] - a facility for simulating operations on clusters that enables repeatable but pseudo-random exploration of state space and correctness testing. This will bolster the already formidable testing capabilities the Cassandra community offers and represents a true advancement in the state-of-the-art for distributed systems testing.
@@ -23,6 +24,7 @@ Already we have seen CEPs approved and in development, such as:
 * https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-16%3A+Auth+Plugin+Support+for+CQLSH[Auth Plugin Support for CQLSH,window=_blank] - CQLSH, the included CLI tool, is important and useful, but, unfortunately, lacks the same support for different authentication methods. This will allow anyone using third-party-provided plugins like LDAP, Kerberos, and Sigv4 to be able to continue to use CQSLH.
 
 Many other CEPs are being proposed and nearing a vote for approval, such as:
+
 * https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-7%3A+Storage+Attached+Index[Storage Attached Indexing (SAI),window=_blank] - this is another CEP nearing a vote, which is designed to replace the original secondary indexing. This will enable users to index multiple columns on the same table without suffering scaling problems, especially at write time.
 
 While there are proposals to add some headline-grabbing features, such as JOIN support to Apache Cassandra, some features confirm work that has already been undertaken. For example, the experimental flag for Java 11 has been removed and is now officially supported, while development to support Java 17 is in full swing and Cassandra will take advantage of the rapidly evolving innovations in Java garbage collection. As we’ve already seen in https://jaxenter.com/apache-cassandra-java-174575.html[performance tests for JDK16,window=_blank], Z Garbage Collection (ZGC) is now delivering submillisecond pause times, and we expect more significant gains in the near future.


### PR DESCRIPTION
- Blog post titled "What the Future Holds for Apache Cassandra"
- Modified blog index page

- Fixed formatting errors on Apache Cassandra Changelog 10 