### PR TITLE
CASSANDRA-16913: Updated build-ui.zip URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 /site-content/site.yaml
 /site-content/build/
 
-/site-ui/build/
 /site-ui/node_modules/
 /site-ui/public/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To build the website only, run the following command from within the `./cassandr
 $ ./run.sh website build
 ```
 
-This will build the website content using your local copy of the cassandra-website, and the current checked-out branch. Use this command if you want to make a change to a top-level webpage without building the docs for any versions of cassandra.
+This will use the current checked-out branch of your cassandra-website local copy to build the website content. In addition, the local copy of the UI bundle will be used to style the website content. Use this command if you want to make a change to a top-level webpage without building the docs for any versions of cassandra.
 
 Once building has completed, the HTML content will be in the `./site-content/build/html/` directory ready to be reviewed and committed.
 
@@ -225,9 +225,11 @@ $ ./run.sh \
     -u cassandra-website:/local/path/to/cassandra-website/repository
 ```
 
-### Generate the website using local copy of the ui-bundle
+### Generate the website using your own copy of the ui-bundle
 
-You can use your own *ui-bundle.zip* file containing the information on how to style the website when building it. The *ui-bundle.zip* file can be generated using the `./run.sh` script. See the [Building the Site UI](#building-the-site-ui) section for furher details on how to build the *ui-bundle.zip*.
+By default, the local copy of the *ui-bundle.zip* located in site-ui/build/ is used by Antora to style the website when it is built. The `./run.sh` script will pass the location of ui-bundle.zip to the Docker container that executes Antora.
+
+You can use your own *ui-bundle.zip* file containing the information on how to style the website when building it. The *ui-bundle.zip* file can be generated using the `./run.sh` script. See the [Building the Site UI](#building-the-site-ui) section for further details on how to build the *ui-bundle.zip*.
 
 To supply your own *ui-bundle.zip* file when building the website, run the following command.
 
@@ -242,8 +244,6 @@ $ ./run.sh website build -z https://github.com/apache/cassandra-website/archive/
 ```
 
 The styling contained in the *ui-bundle.zip* will be applied to docs if they are being rendered as well.
-
-By default, the Docker container used to render the site will reference a GitHub release version of the *ui-bundle.zip*.
 
 ## Building the Site UI
 

--- a/site-content/Dockerfile
+++ b/site-content/Dockerfile
@@ -42,8 +42,7 @@ RUN apt-get update && \
         git \
         make \
         ant \
-        ant-optional \
-        vim
+        ant-optional
 
 RUN pip3 install jinja2 requests
 
@@ -99,7 +98,7 @@ ENV ANTORA_CONTENT_SOURCES_CASSANDRA_WEBSITE_BRANCHES="HEAD"
 ENV ANTORA_CONTENT_SOURCES_CASSANDRA_WEBSITE_TAGS=""
 ENV ANTORA_CONTENT_SOURCES_CASSANDRA_WEBSITE_START_PATH="site-content/source"
 
-ENV ANTORA_UI_BUNDLE_URL="https://github.com/ianjevans/antora-ui-datastax/releases/download/v0.1oss/ui-bundle.zip"
+ENV ANTORA_UI_BUNDLE_URL="https://github.com/apache/cassandra-website/raw/trunk/site-ui/build/ui-bundle.zip"
 
 ENV CASSANDRA_DOWNLOADS_URL="https://downloads.apache.org/cassandra/"
 


### PR DESCRIPTION
* Generated bundle-ui.zip and added it to repository under site-ui/build/
* Updated bundle-ui URL in site-content Dockerfile to point to GitHub trunk version of build-ui.zip

patch by Anthony Grasso; reviewed by ... for CASSANDRA-16913