### PR TITLE
CASSANDRA-17274: Fix link syntax community component

### DIFF
--- a/site-content/source/modules/ROOT/pages/community.adoc
+++ b/site-content/source/modules/ROOT/pages/community.adoc
@@ -331,7 +331,7 @@ https://www.apache.org/theapacheway/index.html[The Apache Way,window=blank]
 
 [openblock, float75 full-800]
 ----------
-Contributors are individuals who contribute patches—source code, documentation, help on mailing lists, website—to Apache projects. While contributors do not have a specific governance role, they are crucial to the project’s success. Read the docs to learn how to {site-url}doc/latest/development/index.html[contribute to Cassandra,window=blank], and review our https://cwiki.apache.org/confluence/display/CASSANDRA/Apache+Cassandra+Project+Governance[governance,window=blank] page to understand how we vote on code contributions.
+Contributors are individuals who contribute patches—source code, documentation, help on mailing lists, website—to Apache projects. While contributors do not have a specific governance role, they are crucial to the project’s success. Read the docs to learn how to link:{site-url}_/development/index.html[contribute to Cassandra,window=blank], and review our https://cwiki.apache.org/confluence/display/CASSANDRA/Apache+Cassandra+Project+Governance[governance,window=blank] page to understand how we vote on code contributions.
 ----------
 --------
 // end row


### PR DESCRIPTION
Previously, link for contribute to cassandra was broken and rendered as
plaintext instead of a link tag, this was because the link was a
relative instead of absolute link and URL macro was not able to
understand that.

Using link macro solved the issue and corrected the path to
development/index.html for contribute to cassandra.

After:

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/18033231/150470730-e723fc58-d13c-49b1-9c9a-b7050c1cb08c.png">

Before:

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/18033231/150470747-1136fee4-1728-42f0-a9c4-f40517aeee38.png">
