### PR TITLE
date change for "Tightening security for Apache Cassandra: Part 2" blog

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog.adoc
+++ b/site-content/source/modules/ROOT/pages/blog.adoc
@@ -16,7 +16,7 @@ NOTES FOR CONTENT CREATORS
 [discrete]
 === Tightening Security for Apache Cassandra: Part 2
 [discrete]
-==== February 4, 2022
+==== February 7, 2022
 ------
 [openblock,card-content]
 ------

--- a/site-content/source/modules/ROOT/pages/blog/Tightening-Security-for-Apache-Cassandra-Part-2.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Tightening-Security-for-Apache-Cassandra-Part-2.adoc
@@ -1,7 +1,7 @@
 = Tightening security for Apache Cassandra: Part 2
 :page-layout: single-post
 :page-role: blog-post
-:page-post-date: February, 4 2022
+:page-post-date: February, 7 2022
 :page-post-author: Maulin Vasavada
 :description: The Apache Cassandra Community
 


### PR DESCRIPTION
date change from February 4, 2022 to February 7, 2022 on blog index and in the blog post