### PR TITLE
Fixing social icon sizing caching issue

### DIFF
--- a/site-ui/src/css/tt_styles.css
+++ b/site-ui/src/css/tt_styles.css
@@ -1171,7 +1171,7 @@ p {
 }
 
 .header-social-icons a {
-  margin-left: 45px;
+  margin-left: 20px;
 }
 
 .footer-social-icons a {

--- a/site-ui/src/partials/docs-header-content.hbs
+++ b/site-ui/src/partials/docs-header-content.hbs
@@ -1,11 +1,18 @@
 
 <header id="top-nav">
     <div class="inner relative">
-        <div class="logo"><a href="{{{ site.url }}}"><img src="{{{uiRootPath}}}/img/logo-white.svg" alt=""></a></div>
-        <div class="mobile-nav-icon right">
-            <img class="toggle-icon" src="{{{uiRootPath}}}/img/hamburger-nav.svg">
+         <div class="header-social-icons text-right">
+            <a href="https://twitter.com/cassandra?lang=en" target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/twitter-icon-circle-white.svg" alt="twitter icon" width="24"></a>
+            <a href="https://www.linkedin.com/company/apache-cassandra/"  target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/LI-In-Bug.png" alt="linked-in icon" width="24"></a>
+            <a href="https://www.youtube.com/c/PlanetCassandra" target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/youtube-icon.png" alt="youtube icon" width="24"></a>
         </div>
-       {{> header-nav}}
+        <div class="cf">
+            <div class="logo left"><a href="{{{ site.url }}}"><img src="{{{uiRootPath}}}/img/logo-white.svg" alt=""></a></div>
+            <div class="mobile-nav-icon right">
+                <img class="toggle-icon" src="{{{uiRootPath}}}/img/hamburger-nav.svg">
+            </div>
+            {{> header-nav}}
+        </div>
     </div>
 </header>
 

--- a/site-ui/src/partials/footer-content.hbs
+++ b/site-ui/src/partials/footer-content.hbs
@@ -8,9 +8,9 @@
             <div id="footer-logo" class="logo logo--footer mb-medium"><img src="{{{uiRootPath}}}/img/logo-white.svg" alt=""></div>
             <p>Apache Cassandra powers mission-critical deployments with improved performance and unparalleled levels of scale in the cloud.</p>
             <div class="footer-social-icons">
-                <a href="https://twitter.com/cassandra?lang=en" target="_blank"><img src="{{{uiRootPath}}}/img/twitter-icon-circle-white.svg" alt="twitter icon"></a>
-                <a href="https://www.linkedin.com/company/apache-cassandra/" target="_blank"><img src="{{{uiRootPath}}}/img/LI-In-Bug.png" alt="linked-in icon"></a>
-                 <a href="https://www.youtube.com/c/PlanetCassandra" target="_blank"><img src="{{{uiRootPath}}}/img/youtube-icon.png" alt="youtube icon"></a>
+                <a href="https://twitter.com/cassandra?lang=en" target="_blank"><img src="{{{uiRootPath}}}/img/twitter-icon-circle-white.svg" alt="twitter icon" width="24"></a>
+                <a href="https://www.linkedin.com/company/apache-cassandra/" target="_blank"><img src="{{{uiRootPath}}}/img/LI-In-Bug.png" alt="linked-in icon" width="24"></a>
+                 <a href="https://www.youtube.com/c/PlanetCassandra" target="_blank"><img src="{{{uiRootPath}}}/img/youtube-icon.png" alt="youtube icon" width="24"></a>
             </div>
         </div>
         <div class="col-2 flex flex-center">

--- a/site-ui/src/partials/header-content.hbs
+++ b/site-ui/src/partials/header-content.hbs
@@ -2,9 +2,9 @@
 <header id="top-nav">
     <div class="inner relative">
         <div class="header-social-icons text-right">
-            <a href="https://twitter.com/cassandra?lang=en" target="_blank"><img src="{{{uiRootPath}}}/img/twitter-icon-circle-white.svg" alt="twitter icon"></a>
-            <a href="https://www.linkedin.com/company/apache-cassandra/"  target="_blank"><img src="{{{uiRootPath}}}/img/LI-In-Bug.png" alt="linked-in icon"></a>
-            <a href="https://www.youtube.com/c/PlanetCassandra" target="_blank"><img src="{{{uiRootPath}}}/img/youtube-icon.png" alt="youtube icon"></a>
+            <a href="https://twitter.com/cassandra?lang=en" target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/twitter-icon-circle-white.svg" alt="twitter icon" width="24"></a>
+            <a href="https://www.linkedin.com/company/apache-cassandra/"  target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/LI-In-Bug.png" alt="linked-in icon" width="24"></a>
+            <a href="https://www.youtube.com/c/PlanetCassandra" target="_blank" styles="margin-left: 20px;"><img src="{{{uiRootPath}}}/img/youtube-icon.png" alt="youtube icon" width="24"></a>
         </div>
         <div class="cf">
             <div class="logo left"><a href="{{{ site.url }}}"><img src="{{{uiRootPath}}}/img/logo-white.svg" alt=""></a></div>


### PR DESCRIPTION
I added defined widths to the img tags themselves so even in the user has a cached style sheet, the icons will look fine. I also just modified the spacing of the icons because it seemed like people didn't like having so much space between them