### PR TITLE
Update quickstart.adoc

### DIFF
--- a/site-content/source/modules/ROOT/pages/quickstart.adoc
+++ b/site-content/source/modules/ROOT/pages/quickstart.adoc
@@ -119,6 +119,7 @@ Connected to Test Cluster at cassandra:9042.
 Use HELP for help.
 cqlsh>
 --
+Note again: The cassandra server itself (the first docker run command you ran) takes a few seconds to start up. The above command will throw an error if the server hasn't finished its init sequence yet, so give it a few seconds to spin up.
 ====
 // end example 
 


### PR DESCRIPTION
Adding note for people who go straight to the cqlsh to wait for the cassandra server to startup - and not presume they have done something wrong.