### PR TITLE
Fix typo for opening new tab and add card to blog.adoc

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog.adoc
+++ b/site-content/source/modules/ROOT/pages/blog.adoc
@@ -14,6 +14,30 @@ NOTES FOR CONTENT CREATORS
 [openblock,card-header]
 ------
 [discrete]
+=== 2023 Google Season of Documentation Proposal 
+[discrete]
+==== February 27, 2023
+------
+[openblock,card-content]
+------
+We have applied to the GSoD with this proposal!
+
+[openblock,card-btn card-btn--blog]
+--------
+[.btn.btn--alt]
+xref:blog/GSoD-Proposal-2023.adoc[Read More]
+--------
+
+------
+----
+//end card
+
+//start card
+[openblock,card shadow relative test]
+----
+[openblock,card-header]
+------
+[discrete]
 === Apache Cassandra Summit Agenda Announced
 [discrete]
 ==== January 18, 2023

--- a/site-content/source/modules/ROOT/pages/blog/GSoD-Proposal-2023.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/GSoD-Proposal-2023.adoc
@@ -20,9 +20,9 @@ That includes people changing careers, those who are self-taught, those returnin
 The goal is to create a starting point for anyone who isn’t sure how to get started in open source or uncertain whether open source communities would welcome their contributions.
 The mentor this year will be Lorina Poland, an Apache Cassandra committer and technical writer with 10 years of experience writing about Cassandra.
 
-You can find more details about the program on the official https://https://developers.google.com/season-of-docs/docs/tech-writer-guide [GSoD^] website.
+You can find more details about the program on the official https://https://developers.google.com/season-of-docs/docs/tech-writer-guide [GSoD, window="_blank"] website.
 
-If you are interested in applying to participate on Apache Cassandra during GSoD, please join the *#cassandra-docs* room on https://infra.apache.org/slack.html[Slack^] and introduce yourself!
+If you are interested in applying to participate on Apache Cassandra during GSoD, please join the *#cassandra-docs* room on https://infra.apache.org/slack.html[Slack, window="_blank"] and introduce yourself!
 Bookmark this page, so you can come back and check if our proposal was won a 2023 spot.
 
 The best GSoD participants are self-motivated and proactive, so familiarize yourself with the https://cassandra.apache.org/doc/latest/[current documentation]. Good luck!

--- a/site-content/source/modules/ROOT/pages/blog/GSoD-Proposal-2023.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/GSoD-Proposal-2023.adoc
@@ -20,7 +20,7 @@ That includes people changing careers, those who are self-taught, those returnin
 The goal is to create a starting point for anyone who isn’t sure how to get started in open source or uncertain whether open source communities would welcome their contributions.
 The mentor this year will be Lorina Poland, an Apache Cassandra committer and technical writer with 10 years of experience writing about Cassandra.
 
-You can find more details about the program on the official https://https://developers.google.com/season-of-docs/docs/tech-writer-guide [GSoD, window="_blank"] website.
+You can find more details about the program on the official https://https://developers.google.com/season-of-docs/docs/tech-writer-guide[GSoD, window="_blank"] website.
 
 If you are interested in applying to participate on Apache Cassandra during GSoD, please join the *#cassandra-docs* room on https://infra.apache.org/slack.html[Slack, window="_blank"] and introduce yourself!
 Bookmark this page, so you can come back and check if our proposal was won a 2023 spot.


### PR DESCRIPTION
I have corrected two "open new tab" items that were not working correctly. I also added a card to blog.adoc to display the GSoD proposal in the blog posts page.

Ticket for work is: https://issues.apache.org/jira/browse/CASSANDRA-18284

@michaelsembwever @mck - here is the followup. Once this ticket is merged, I believe it will be ready for publishing.