### PR TITLE
Update quickstart.adoc

### DIFF
--- a/site-content/source/modules/ROOT/pages/quickstart.adoc
+++ b/site-content/source/modules/ROOT/pages/quickstart.adoc
@@ -90,7 +90,7 @@ The CQL shell, or cqlsh, is one tool to use in interacting with the database. We
 [source]
 --
 
-docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 -e CQLVERSION=3.4.5 nuvo/docker-cqlsh 
+docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 -e CQLVERSION=3.4.6 nuvo/docker-cqlsh 
 
 --
 Note: The cassandra server itself (the first docker run command you ran) takes a few seconds to start up. The above command will throw an error if the server hasn't finished its init sequence yet, so give it a few seconds to spin up.


### PR DESCRIPTION
CQL version for latest cassandra is 3.4.6 
If you run the given command, it will fail with the message unsupported version of CQL.

> Connection error: ('Unable to connect to any servers', {'10.89.1.4': ProtocolError("cql_version '3.4.5' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.6']",)})
