### PR TITLE
Include the Catalyst vs ASF roles distinction in the Catalyst Program

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog/Introducing-the-Apache-Cassandra-Catalyst-Program.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Introducing-the-Apache-Cassandra-Catalyst-Program.adoc
@@ -4,35 +4,35 @@
 :page-post-date: December 1, 2023
 :page-post-author: Apache Cassandra PMC
 :description: announcement of the Apache Cassandra Catalyst program
-:keywords: 
+:keywords:
 
-One of the cornerstones of https://www.apache.org/theapacheway/[The Apache Way^] is "community over code," the belief that the most sustainable and healthy projects are those that value a diverse and collaborative community. By working together, strong communities can rectify problems that arise during code development and can better evolve a project to meet technology demands. 
+One of the cornerstones of https://www.apache.org/theapacheway/[The Apache Way^] is "community over code," the belief that the most sustainable and healthy projects are those that value a diverse and collaborative community. By working together, strong communities can rectify problems that arise during code development and can better evolve a project to meet technology demands.
 
-Today we are excited to announce the xref:cassandra-catalyst-program.adoc[Apache Cassandra Catalyst program], an effort that aims to recognize individuals who invest in the growth of the Apache Cassandra community by enthusiastically sharing their expertise, encouraging participation, and creating a welcoming environment. This is the first PMC-led community program of its kind within the Apache Software Foundation (ASF) ecosystem, and we hope it inspires other ASF projects to find similar ways to recognize individuals who catalyze community participation. 
+Today we are excited to announce the xref:cassandra-catalyst-program.adoc[Apache Cassandra Catalyst program], an effort that aims to recognize individuals who invest in the growth of the Apache Cassandra community by enthusiastically sharing their expertise, encouraging participation, and creating a welcoming environment. This is the first PMC-led community program of its kind within the Apache Software Foundation (ASF) ecosystem, and we hope it inspires other ASF projects to find similar ways to recognize individuals who catalyze community participation.
 
 Below you’ll find a couple of questions we feel are important to address right away, but for more information, you can visit the xref:cassandra-catalyst-program.adoc[Cassandra Catalyst Program page] and https://docs.google.com/forms/d/e/1FAIpQLScQ6FJZ9Z6Jpym0q1KUXzjnzEsHJvsmjQ3R6KEs6Qs8Jg7W_Q/viewform[nominate someone or apply^].
 
-**What does it mean to be a Cassandra Catalyst?** 
+**What does it mean to be a Cassandra Catalyst?**
 
 Catalysts are trustworthy, expert contributors with a passion for connecting and empowering others with Cassandra knowledge. The individuals must be able to demonstrate strong knowledge of Cassandra such as production deployments, educational material, conference talks, or other ways. In broad terms, Catalyst can participate in two groups of activities:
 
-* **Contribution**: Engaging with the project and community in a myriad of ways including responding to community questions, welcoming new members; or engaging in JIRA tickets. 
-* **Promotion**: Telling others about Cassandra, on and offline. This can include promoting the project on social media; publishing Cassandra content so that others can learn more about Cassandra; speaking about Cassandra at an event; or organizing an event for the community. 
+* **Contribution**: Engaging with the project and community in a myriad of ways including responding to community questions, welcoming new members; or engaging in JIRA tickets.
+* **Promotion**: Telling others about Cassandra, on and offline. This can include promoting the project on social media; publishing Cassandra content so that others can learn more about Cassandra; speaking about Cassandra at an event; or organizing an event for the community.
 
-**Who can become a Cassandra Catalyst?** 
+**Who can become a Cassandra Catalyst?**
 
-Anyone can nominate an individual to become a Catalyst or apply themselves. This program applies to existing contributors who have been involved in Cassandra for years or those who are newcomers to the community. 
+Anyone can nominate an individual to become a Catalyst or apply themselves. This program applies to existing contributors who have been involved in Cassandra for years or those who are newcomers to the community.
 
-**How is this different from being a Cassandra committer?** 
+**How is this different from being a Cassandra committer?**
 
-The Catalyst award is not to be confused with the https://cassandra.apache.org/_/community.html#how-to-contribute[project’s committership or being on its PMC^], roles that involve project participation and contributions. The Catalyst program is recognition for effort of any type around the project, and is not a position or title within the project or the ASF. 
+The Catalyst award is not to be confused with the https://cassandra.apache.org/_/community.html#how-to-contribute[project’s committership or being on its PMC^], roles that involve project participation and contributions. The Catalyst program is recognition for effort of any type around the project, and is not a position or title within the project or the ASF.
 
 **What are the benefits of becoming a Catalyst?**
 
-Cassandra Catalysts will be formally recognized for their ongoing work to foster a more collaborative and robust Cassandra community. Catalysts will be listed in several ways including posted to the Cassandra website; announced at community events; given a digital badge for social media profiles; and inclusion in a private channel on the ASF Slack for networking. 
+Cassandra Catalysts will be formally recognized for their ongoing work to foster a more collaborative and robust Cassandra community. Catalysts will be listed in several ways including posted to the Cassandra website; announced at community events; given a digital badge for social media profiles; and inclusion in a private channel on the ASF Slack for networking.
 
 **How does someone become a Catalyst?**
 
 Individuals can become Catalysts by applying through an https://docs.google.com/forms/d/e/1FAIpQLScQ6FJZ9Z6Jpym0q1KUXzjnzEsHJvsmjQ3R6KEs6Qs8Jg7W_Q/viewform[online form^] where their nomination will be reviewed by the Catalyst committee and endorsed by the PMC. They will need to submit proof and details of their activity in the Apache Cassandra community. Nominations will be open every 12 months and will be announced on all Apache Cassandra channels.
 
-We plan to announce the first group of Catalysts at the upcoming https://events.linuxfoundation.org/cassandra-summit/[Cassandra Summit^] on December 12-13 in San Jose, California. For those interested in applying, be sure to do so before Friday, December 8 at 5:00 p.m. UTC to be included in this first announcement. 
+We plan to announce the first group of Catalysts at the upcoming https://events.linuxfoundation.org/cassandra-summit/[Cassandra Summit^] on December 12-13 in San Jose, California. For those interested in applying, be sure to do so before Friday, December 8 at 5:00 p.m. UTC to be included in this first announcement.

--- a/site-content/source/modules/ROOT/pages/cassandra-catalyst-program.adoc
+++ b/site-content/source/modules/ROOT/pages/cassandra-catalyst-program.adoc
@@ -93,7 +93,7 @@ Creating content about Cassandra is a great way to contribute to the ongoing gro
 [discrete]
 ==== Speaking about Cassandra
 
-Events are a vital part of community engagement and growth. As such, speaking at them is a great way to spread the word about Cassandra. These events can be in-person or virtual and could be organized by the Cassandra community (e.g. monthly Town Halls) or external events that are relevant to the interests of the Cassandra project. 
+Events are a vital part of community engagement and growth. As such, speaking at them is a great way to spread the word about Cassandra. These events can be in-person or virtual and could be organized by the Cassandra community (e.g. monthly Town Halls) or external events that are relevant to the interests of the Cassandra project.
 
 [discrete]
 ==== Organizing Cassandra events
@@ -116,6 +116,17 @@ All Catalysts will be formally recognized as a ‘Cassandra Catalyst’. This co
 * Occasional swag/giveaways (dependent on community funding)
 
 Catalysts will be recognized for their ongoing work to foster a more collaborative and robust Cassandra community. New Catalysts will be announced as they are confirmed and Catalyst status will be reviewed every 12 months.
+
+----
+
+[openblock,image-expand inner inner--narrow py-large cf text-left]
+----
+[discrete]
+=== ASF Compliance
+[discrete]
+==== Catalyst vs. ASF Committer and PMC roles
+
+The Catalyst award is not to be confused with the project’s committership or being on its PMC, roles that involve project participation and contributions. The Catalyst program is recognition for effort of any type around the project, and is not a position or title within the project or the ASF.
 
 ----
 


### PR DESCRIPTION
```
 patch by Mick Semb Wever; reviewed by Dinesh Joshi, Paulo Motta
```


Lots of trailing whitespace removal here.  See comment for main change.