### PR TITLE
fix: remove the paragraph tag from "ecosystem.adoc"

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -18,7 +18,7 @@ https://aiven.io/cassandra[Aiven for Apache Cassandra,window=_blank]: Aiven for 
 
 https://aws.amazon.com/keyspaces/[Amazon Keyspaces (for Apache Cassandra),window=_blank]: Scalable, highly available, and managed Apache Cassandra–compatible database service.
 
-https://docs.microsoft.com/en-us/azure/cosmos-db/cassandra-introduction[Azure Cosmos DB Cassandra API,window=_blank]: Enables you to interact with data stored in https://docs.microsoft.com/en-us/azure/cosmos-db/introduction[Azure Cosmos DB,window=_blank] using the Cassandra Query Language (CQL) , Cassandra-based tools (like cqlsh) and Cassandra client drivers that you're already familiar with.</p>
+https://docs.microsoft.com/en-us/azure/cosmos-db/cassandra-introduction[Azure Cosmos DB Cassandra API,window=_blank]: Enables you to interact with data stored in https://docs.microsoft.com/en-us/azure/cosmos-db/introduction[Azure Cosmos DB,window=_blank] using the Cassandra Query Language (CQL) , Cassandra-based tools (like cqlsh) and Cassandra client drivers that you're already familiar with.
 
 https://azure.microsoft.com/en-us/services/managed-instance-apache-cassandra/[Azure Managed Instance for Apache Cassandra,window=_blank]: Azure Managed Instance for Apache Cassandra is a service offering moderate management, elasticity, and instance-based pricing for Cassandra data. Go beyond traditional lift and shift by expanding your Cassandra workloads to the cloud and keep control over what matters to you.
 


### PR DESCRIPTION
Hey Maintainers, 

I just reading the Cassandra documentation through this url https://cassandra.apache.org/_/ecosystem.html and found one minor issue. The paragraph tag is attached with text is inappropriate way, attached the screenshot below:
![Screenshot 2024-04-29 at 1 54 55 PM](https://github.com/apache/cassandra-website/assets/46045014/813da7e5-c4fa-4b46-a6a5-a399707c05e1)

So I raise the PR with the correction resolution with in it. Here is the working code & build preview of the website for your referenece below:
![Screenshot 2024-04-29 at 1 58 32 PM](https://github.com/apache/cassandra-website/assets/46045014/99c4cf72-3f05-4e6e-a86f-246e42a87559)

Kindly request to maintainers please review this PR.
