### PR TITLE
Update ecosystem.adoc with DbVisualizer SQL client for Cassandra

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -87,6 +87,8 @@ https://downloads.datastax.com/#bulk-loader[DataStax Bulk Loader,window=blank]: 
 
 https://github.com/datastax/metric-collector-for-apache-cassandra[DataStax Metrics Collector for Cassandra,window=blank]: Based on Collectd, aggregates OS and Cassandra metrics along with diagnostic events to facilitate problem resolution and remediation
 
+https://www.dbvis.com/database/cassandra/[DbVisualizer SQL client for Cassandra,window=blank]: DbVisualizer is a comprehensive SQL client and database tool that offers support for Cassandra. It enables users to execute complex SQL queries, visualize data, and manage database schemas. With a user-friendly interface and powerful features like data browsing, data export/import, and advanced visualization tools, DbVisualizer makes it easy to work with Cassandra databases.
+
 https://github.com/uber-go/dosa[DOSA,window=blank]: DOSA is a storage framework that provides a declarative object storage abstraction for applications in Golang and (soon) Java.
 
 https://doc.dovecot.org/admin_manual/cassandra/cassandra/[Dovecot,window=blank]: is among the best performing IMAP servers while still supporting the standard mbox and Maildir formats.


### PR DESCRIPTION
We added our sql tool DbVisualizer that has extended support for Cassandra object types to the Ecosystem page.