### PR TITLE
Update Authentication Plugin Support for CQLSH page

### DIFF
--- a/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-4.1-Features-Authentication-Plugin-Support-for-CQLSH.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-4.1-Features-Authentication-Plugin-Support-for-CQLSH.adoc
@@ -57,7 +57,7 @@ The auth_provider section details a `module` which is the path to the class and 
 ```
 [auth_provider]
 module = mycassandra.auth.foo
-class = BarAuthProvider
+classname = BarAuthProvider
 ```
 
 === Adding Parameters
@@ -67,7 +67,7 @@ To specify non-secret properties, we can simply add the names in the same sectio
 ```
 [auth_provider]
 module = mycassandra.auth.foo
-class = BarAuthProvider
+classname = BarAuthProvider
 property1 = value
 ```
 


### PR DESCRIPTION
Fixes parameter name which should be `classname` instead of `class`.