### PR TITLE
Added Ksolves Website url under professional support in ecosystem html

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -339,6 +339,8 @@ https://digitalis.io/apache-cassandra-services/[Digitalis Services,window=blank]
 
 https://www.instaclustr.com/services/[Instaclustr,window=blank]
 
+https://www.ksolves.com/apache-cassandra-development-company/[Big Data Service & Support,window=blank]
+
 https://opencredo.com/about-us/[Open Credo,window=blank]
 
 https://rustyrazorblade.com/[RustyRazorBlade Consulting,window=blank]


### PR DESCRIPTION
We have added Ksolves Apache cassandra Url under Professional Support in https://cassandra.apache.org/_/ecosystem.html url. 