### PR TITLE
Update download link for Cassandra Java Driver 4.19.1

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -87,13 +87,15 @@ https://www.apache.org/dyn/closer.lua/cassandra/4.0.19/apache-cassandra-4.0.19-b
 [discrete]
 === Latest Cassandra Java Driver
 [discrete]
+==== Latest release on 2025-10-21
+[discrete]
 ==== Apache 4.x Java driver for Cassandra
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0.tar.gz[4.19.0,window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz[4.19.1,window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0.tar.gz.sha512[sha512,window=blank]) +
-(https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0-source.tar.gz[source,window=blank]: https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.0/apache-cassandra-java-driver-4.19.0-source.tar.gz.sha512[sha512,window=blank])
+(https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.sha512[sha512,window=blank]) +
+(https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz[source,window=blank]: https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.sha512[sha512,window=blank])
 
 Java drivers for Cassandra are also available on
 https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Maven Central,window=blank].


### PR DESCRIPTION
Also adds "Latest Release" line

<img width="1203" height="642" alt="4191" src="https://github.com/user-attachments/assets/1cac6ae4-cbcb-4968-8804-5a203edb1259" />
