### PR TITLE
Add CQLAI to ecosystem documentation

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -83,6 +83,8 @@ https://github.com/hhandoko/cassandra-migration[Cassandra Migration,window=blank
 
 https://github.com/criteo/cassandra_exporter[Cassandra Prometheus Exporter,window=blank]: Standalone application which exports Cassandra metrics through a prometheus friendly endpoint
 
+https://github.com/axonops/cqlai[CQLAI,window=blank]: A modern, AI-powered CQL shell for Apache Cassandra with rich terminal UI, natural language query generation, and cqlsh compatibility - built as a single binary in Go with no dependencies.
+
 http://github.com/pyr/cyanite[Cyanite,window=blank]: Cyanite is a daemon which provides services to store and retrieve timeseries data.
 
 https://downloads.datastax.com/#bulk-loader[DataStax Bulk Loader,window=blank]: Easy-to-use command line utility for loading and unloading JSON or CSV files to/from the database, counting rows in tables and identifying large partitions.


### PR DESCRIPTION
Added a new entry for CQLAI, an AI-powered CQL shell for Apache Cassandra.