### PR TITLE
Remove binary tarball references on download page

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -77,9 +77,10 @@ https://www.apache.org/dyn/closer.lua/cassandra/4.0.19/apache-cassandra-4.0.19-b
 ==== CVE fixes may be applied to unmaintained versions as decided on a case-by-case basis.
 [discrete]
 ==== The PGP keys used to sign releases are available in this https://downloads.apache.org/cassandra/KEYS[KEYS,window=_blank] file.
-----------
 
 {empty} +
+
+----------
 
 [openblock, inline50 inline-top]
 ----------
@@ -87,22 +88,19 @@ https://www.apache.org/dyn/closer.lua/cassandra/4.0.19/apache-cassandra-4.0.19-b
 [discrete]
 === Latest Cassandra Java Driver
 [discrete]
-==== Latest release on 2025-10-21
-[discrete]
 ==== Apache 4.x Java driver for Cassandra
+[discrete]
+==== Latest release on 2025-11-18
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz[4.19.1,window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.2/apache-cassandra-java-driver-4.19.2-source.tar.gz[4.19.2 (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1.tar.gz.sha512[sha512,window=blank]) +
-(https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz[source,window=blank]: https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.1/apache-cassandra-java-driver-4.19.1-source.tar.gz.sha512[sha512,window=blank])
+(https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.2/apache-cassandra-java-driver-4.19.2-source.tar.gz[source,window=blank]: https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.2/apache-cassandra-java-driver-4.19.2-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.2/apache-cassandra-java-driver-4.19.2-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.2/apache-cassandra-java-driver-4.19.2-source.tar.gz.sha512[sha512,window=blank])
 
 Java drivers for Cassandra are also available on
 https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Maven Central,window=blank].
 
 ----------
-
-{empty} +
 
 [openblock, inline50 inline-top]
 ----------
@@ -111,11 +109,13 @@ https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Mave
 === Latest Cassandra Go Driver
 [discrete]
 ==== Apache 2.x GoCQL driver for Cassandra
+[discrete]
+==== Latest release on 2025-10-16
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz[2.0.0,window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz[2.0.0 (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha512[sha512,window=blank]) +
+(https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz[source,window=blank]: https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha512[sha512,window=blank]) +
 
 GoCQL driver for Cassandra is also available on https://github.com/apache/cassandra-gocql-driver[Github,window=blank].
 


### PR DESCRIPTION
Removing links to the current binary tarball and replacing them with links to the source tarball.  References to Maven Central will be used for those wanting the binary artifacts.