### PR TITLE
Update import statements to follow consistent ordering rules

### DIFF
--- a/site-content/source/modules/ROOT/pages/development/code_style.adoc
+++ b/site-content/source/modules/ROOT/pages/development/code_style.adoc
@@ -157,14 +157,23 @@ Observe the following order for your imports:
 
 [source,java]
 ----
-java
+java.*
 [blank line]
-com.google.common
-org.apache.commons
-org.junit
-org.slf4j
+javax.*
 [blank line]
-everything else alphabetically
+com.*
+[blank line]
+net.*
+[blank line]
+org.*
+[blank line]
+accord.*
+[blank line]
+org.apache.cassandra.*
+[blank line]
+all other imports
+[blank line]
+static all other imports
 ----
 
 ==== Logging


### PR DESCRIPTION
Import statements habe been updated in cassandra-website repository to align with the import ordering standards established by CASSANDRA-17925. This ensures consistent code style across the project and improves maintainability.