### PR TITLE
CASSANDRA-21155: Fix CQL version errors in QuickStart guide

### DIFF
--- a/site-content/source/modules/ROOT/pages/quickstart.adoc
+++ b/site-content/source/modules/ROOT/pages/quickstart.adoc
@@ -90,7 +90,7 @@ The CQL shell, or cqlsh, is one tool to use in interacting with the database. We
 [source]
 --
 
-docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 -e CQLVERSION=3.4.6 nuvo/docker-cqlsh 
+docker run --rm --network cassandra -v "$(pwd)/data.cql:/scripts/data.cql" -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 -e CQLVERSION=3.4.7 nuvo/docker-cqlsh
 
 --
 Note: The cassandra server itself (the first docker run command you ran) takes a few seconds to start up. The above command will throw an error if the server hasn't finished its init sequence yet, so give it a few seconds to spin up.
@@ -107,7 +107,7 @@ Much like an SQL shell, you can also of course use CQLSH to run CQL commands int
 
 [source]
 --
-docker run --rm -it --network cassandra nuvo/docker-cqlsh cqlsh cassandra 9042 --cqlversion='3.4.5' 
+docker run --rm -it --network cassandra nuvo/docker-cqlsh cqlsh cassandra 9042 --cqlversion='3.4.7'
 --
 
 This should get you a prompt like so:
@@ -115,7 +115,7 @@ This should get you a prompt like so:
 [source]
 --
 Connected to Test Cluster at cassandra:9042.
-[cqlsh 5.0.1 | Cassandra 4.0.4 | CQL spec 3.4.5 | Native protocol v5]
+[cqlsh 5.0.1 | Cassandra 5.0.6 | CQL spec 3.4.7 | Native protocol v5]
 Use HELP for help.
 cqlsh>
 --


### PR DESCRIPTION
The QuickStart guide currently references CQL versions `3.4.5` and `3.4.6` in the `docker run` commands. However, the `cassandra:latest` image (currently Cassandra 5.0.x) runs **CQL spec 3.4.7**.

Attempting to follow the current guide results in a connection failure because the older CQL versions are not supported by the latest image.

**Verification:**
1. Running the command from the current guide fails:
   `ProtocolError("cql_version '3.4.5' is not supported... Supported versions: [u'3.4.7']")`

2. Running with updated version (3.4.7) succeeds:
   `[cqlsh 5.0.1 | Cassandra 5.0.6 | CQL spec 3.4.7 | Native protocol v5]`

**Changes:**
- Updated `CQLVERSION` env var in Step 4 to `3.4.7`.
- Updated `--cqlversion` flag in Step 5 to `3.4.7`.
- Updated example output in Step 5 to reflect current versions.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-21155