### PR TITLE
Update gocql driver download section (v2.1.1)

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -110,12 +110,12 @@ https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Mave
 [discrete]
 ==== 2.x GoCQL driver for Apache Cassandra
 [discrete]
-==== Latest release on 2025-10-16
+==== Latest release on 2026-04-22
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz[2.0.0 (source),window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.1.1/apache-cassandra-gocql-driver-2.1.1.tar.gz[2.1.1 (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.0.0/apache-cassandra-gocql-driver-2.0.0.tar.gz.sha512[sha512,window=blank]) +
+(https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.1/apache-cassandra-gocql-driver-2.1.1.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.1/apache-cassandra-gocql-driver-2.1.1.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.1/apache-cassandra-gocql-driver-2.1.1.tar.gz.sha512[sha512,window=blank]) +
 
 GoCQL driver for Cassandra is also available on https://github.com/apache/cassandra-gocql-driver[Github,window=blank].
 


### PR DESCRIPTION
Update downloads section with the latest GoCQL v2.1.0 release