### PR TITLE
CASSANDRA-21315: Upgrade docs build stack to Antora 3.1 and Node.js 24 LTS

### DIFF
--- a/site-content/Dockerfile
+++ b/site-content/Dockerfile
@@ -63,10 +63,10 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # Install Node.js for Antora (documentation generation)
 RUN sh -c '\
   set -ex ;\
-  NODE_VERSION="v20.16.0" ;\
+  NODE_VERSION="v24.14.1" ;\
   NODE_PLATFORM=x64 ;\
   [ $(uname -m) = "aarch64" ] && NODE_PLATFORM=arm64 ;\
-  NODE_VERSION_SHAS="c30af7dfea46de7d8b9b370fa33b8b15440bc93f0a686af8601bbb48b82f16c0 1d9929e72f692179f884cd676b2dfabd879cb77defa7869dc8cfc802619277fb" ;\
+  NODE_VERSION_SHAS="84d38715d449447117d05c3e71acd78daa49d5b1bfa8aacf610303920c3322be 71e427e28b78846f201d4d5ecc30cb13d1508ca099ef3871889a1256c7d6f67e" ;\
   NODE_TAR="node-${NODE_VERSION}-linux-${NODE_PLATFORM}.tar.xz" ;\
   wget -q "https://nodejs.org/dist/${NODE_VERSION}/${NODE_TAR}" --no-check-certificate ;\
   NODE_SHA="$(sha256sum ${NODE_TAR} | cut -d" " -f1)" ;\
@@ -77,9 +77,9 @@ RUN sh -c '\
 
 CMD [ "npm", "--version" ]
 
-# Use npm to install Antora globally, and antora-lunr for site search, and js-yaml to load YAML files
-RUN npm i -g @antora/cli@2.3 @antora/site-generator-default@2.3 @djencks/asciidoctor-openblock
-RUN npm i -g antora-lunr antora-site-generator-lunr
+# Use npm to install Antora globally, with Antora 3 search extension and AsciiDoc extensions
+RUN npm i -g @antora/cli@3.1.14 @antora/site-generator@3.1.14 @djencks/asciidoctor-openblock
+RUN npm i -g @antora/lunr-extension
 RUN npm i -g live-server
 
 # Create the build user and make it part of the password-less sudo group

--- a/site-content/docker-entrypoint.sh
+++ b/site-content/docker-entrypoint.sh
@@ -216,7 +216,7 @@ generate_site_yaml() {
 render_site_content_to_html() {
   pushd "${CASSANDRA_WEBSITE_DIR}/site-content" > /dev/null
   log_message "INFO" "Building the site HTML content."
-  antora --generator antora-site-generator-lunr site.yaml
+  antora site.yaml
   log_message "INFO" "Rendering complete!"
   popd > /dev/null
 }
@@ -332,12 +332,6 @@ run_preview_mode() {
   if [ "${COMMAND_BUILD_SITE}" != "run" ]
   then
     generate_site_yaml
-
-    export DOCSEARCH_ENABLED=true
-    export DOCSEARCH_ENGINE=lunr
-    export NODE_PATH="$(npm -g root)"
-    export DOCSEARCH_INDEX_VERSION=latest
-
     render_site_content_to_html
   fi
 
@@ -457,12 +451,6 @@ fi
 if [ "${COMMAND_BUILD_SITE}" = "run" ]
 then
   generate_site_yaml
-
-  export DOCSEARCH_ENABLED=true
-  export DOCSEARCH_ENGINE=lunr
-  export NODE_PATH="$(npm -g root)"
-  export DOCSEARCH_INDEX_VERSION=latest
-
   render_site_content_to_html
   prepare_site_html_for_publication
 fi

--- a/site-content/site.template.yaml
+++ b/site-content/site.template.yaml
@@ -32,6 +32,11 @@ output:
   clean: true
   dir: ./build/html
 
+antora:
+  extensions:
+    - require: '@antora/lunr-extension'
+      index_latest_only: true
+
 asciidoc:
   attributes:
     idprefix: ''


### PR DESCRIPTION
## CASSANDRA-21315

Upgrades the `apache/cassandra-website` docs build pipeline from Antora 2.3 to Antora 3.1.14 and Node.js 20 to Node.js 24 LTS. This is a prerequisite for Cassandra 6 documentation contributions, which were authored and validated against Antora 3.1.

## Changes

**`site-content/Dockerfile`**
- Node.js: `v20.16.0` → `v24.14.1` (current active LTS; SHA256 verified for linux/amd64 and linux/arm64)
- Replace `@antora/cli@2.3` and `@antora/site-generator-default@2.3` with `@antora/cli@3.1.14` and `@antora/site-generator@3.1.14`
- Replace `antora-lunr` and `antora-site-generator-lunr` with `@antora/lunr-extension`

**`site-content/docker-entrypoint.sh`**
- Remove `--generator antora-site-generator-lunr` flag from the Antora invocation
- Remove `DOCSEARCH_ENABLED`, `DOCSEARCH_ENGINE=lunr`, `NODE_PATH`, and `DOCSEARCH_INDEX_VERSION` env exports (required only by the deprecated Antora 2 custom generator)

**`site-content/site.template.yaml`**
- Add `antora.extensions` block registering `@antora/lunr-extension` (Antora 3 extension model for search)
- `asciidoc.extensions` (`tabs-block.js`, `@djencks/asciidoctor-openblock`) left unchanged

## What is NOT changed
- Branch matrix (`trunk`, `cassandra-5.0`, `cassandra-4.1`, `cassandra-4.0`, `cassandra-3.11`)
- `stable` / `latest` alias behavior
- `run.sh` command surface
- JDK selection logic for generated docs per branch
- `tabs-block.js` and `@djencks/asciidoctor-openblock` AsciiDoc extensions

## Validation

- Docker image built clean with Antora 3.1.14 and Node 24.14.1
- Single-branch build (`trunk`) succeeded; `search-index.js` present confirming `@antora/lunr-extension` functional
- Multi-branch build (`trunk`, `cassandra-5.0`, `cassandra-4.1`) succeeded; version directories `4.1/`, `5.0/`, `6.0/`, `latest/`, `stable/` all present
- `stable/` and `latest/` alias behavior confirmed unchanged
- xref errors in build output are pre-existing in upstream trunk content, not regressions from this upgrade

## AI Assistance
This PR was prepared with AI assistance (Claude, Anthropic). All changes were reviewed against the `apache/cassandra-website` source and validated with local builds.