### PR TITLE
Docs broken links fix. Phase 1

### DIFF
--- a/site-content/source/modules/ROOT/pages/apachecon_cfp.adoc
+++ b/site-content/source/modules/ROOT/pages/apachecon_cfp.adoc
@@ -12,9 +12,6 @@ Summit, hosted with ApacheCon in Las Vegas, NV (Sept 9 - 13).
 
 === Apache Cassandra at ApacheCon
 
-image:/img/apachecon-2019.jpg[ApacheCon 2019]\{:style=``float: right;
-width: 400px''}
-
 For more information about other events at ApacheCon, see
 https://apachecon.com/acna19/index.html[ApacheCon 2019].
 

--- a/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-4.0-Overview.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-4.0-Overview.adoc
@@ -21,7 +21,7 @@ Testing included purpose-built new tools to cover every requirement:
 * Fault injection
 * Unit / dtest coverage expansion
 
-Those xref:blog/Testing-Apache-Cassandra-4.html[tools] were perfected and deployed to help meet quality goals and set a baseline for any future version of Cassandra. They provide needed infrastructure to ensure future releases retain the highest levels of quality and correctness. 
+Those xref:blog/Testing-Apache-Cassandra-4.adoc[tools] were perfected and deployed to help meet quality goals and set a baseline for any future version of Cassandra. They provide needed infrastructure to ensure future releases retain the highest levels of quality and correctness. 
 
 
 So, what can you expect from Cassandra 4.0? 

--- a/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-19-September-2022.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-19-September-2022.adoc
@@ -37,7 +37,7 @@ To stay up-to-date, we recommend joining the xref:community.adoc#discussions[Cas
 
 _Updates on Cassandra Enhancement Proposals (CEPs), how to contribute, and other community activities._ 
 
-_For newcomers to the project, we have a useful xref:development/index.adoc[‘Contributing to Cassandra’] page for how to get involved and get started. We would also recommend reading the xref:doc/latest/cassandra/architecture/overview.adoc[overview of the C* architecture^]._
+_For newcomers to the project, we have a useful xref:development/index.adoc[‘Contributing to Cassandra’] page for how to get involved and get started. We would also recommend reading the xref:Cassandra:cassandra:architecture/overview.adoc[overview of the C* architecture^]._
 
 _We use Jira to record project issues. Here’s a handy Jira tip from *Josh McKenzie*: if you want to search for tickets in your area of interest, use this https://issues.apache.org/jira/issues/?jql=project%20%3D%20cassandra%20AND%20resolution%20!%3D%20unresolved%20AND%20assignee%20is%20EMPTY%20AND%20summary%20~%20%27ReplaceTextHere%27%20ORDER%20BY%20priority%20ASC[URL link^]. Simply swap out ‘ReplaceTextHere’ in the URL query string for what you want to find._
 

--- a/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-20-November-2022.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Apache-Cassandra-Changelog-20-November-2022.adoc
@@ -35,7 +35,7 @@ To stay up-to-date, we recommend joining the  xref:community.adoc#discussions[Ca
 
 _Updates on Cassandra Enhancement Proposals (CEPs), how to contribute, and other community activities._ 
 
-_For newcomers to the project, we have a useful xref:development/index.adoc[‘Contributing to Cassandra’] page for how to get involved and get started. We would also recommend reading the xref:doc/latest/cassandra/architecture/overview.adoc[overview of the C* architecture]._
+_For newcomers to the project, we have a useful xref:development/index.adoc[‘Contributing to Cassandra’] page for how to get involved and get started. We would also recommend reading the xref:Cassandra:cassandra:architecture/overview.adoc[overview of the C* architecture]._
 
 We use Jira to record project issues. Here’s a handy Jira tip from *Josh McKenzie*, if you want to search for tickets in your area of interest, use this https://issues.apache.org/jira/issues/?jql=project%20%3D%20cassandra%20AND%20resolution%20!%3D%20unresolved%20AND%20assignee%20is%20EMPTY%20AND%20summary%20~%20%27ReplaceTextHere%27%20ORDER%20BY%20priority%20ASC[URL link^]. Simply swap out ‘ReplaceTextHere’ in the URL query string for what you want to find.
 
@@ -147,7 +147,7 @@ video::ZbJrFy4TlNI[youtube,640,360]
 
 xref:blog/Cassandra-Days-Asia-2022.adoc[Cassandra Days Asia - Hanoi, Jakarta, Singapore] - Erick Ramirez
 
-xref:blog/Cassandra-Day-SC-Bellevue-Houston-Wakanda Forever.adoc[Cassandra Day Santa Clara-Bellevue-Houston + Wakanda Forever] - Erick Ramirez
+xref:blog/Cassandra-Day-SC-Bellevue-Houston-WakandaForever.adoc[Cassandra Day Santa Clara-Bellevue-Houston + Wakanda Forever] - Erick Ramirez
 
 xref:blog/Cassandra-Summit-Returns-in-2023.adoc[Cassandra Summit Returns in 2023] - Cassandra Community
 

--- a/site-content/source/modules/ROOT/pages/blog/Configurable-Storage-Ports-and-Why-We-Need-Them.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Configurable-Storage-Ports-and-Why-We-Need-Them.adoc
@@ -6,8 +6,6 @@
 :description: The Apache Cassandra Community
 :keywords: 
 
-= Configurable Storage Ports and Why We Need Them
-
 image::blog/configurable-storage-ports-and-why-we-need-them-unsplash-bernard-hermant.jpg[storage ports]
 
 Image credit: https://unsplash.com/@bernardhermant?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText[Bernard Hermant on Unsplash,window=_blank]

--- a/site-content/source/modules/ROOT/pages/blog/Even-Higher-Availability-with-5x-Faster-Streaming-in-Cassandra-4.adoc
+++ b/site-content/source/modules/ROOT/pages/blog/Even-Higher-Availability-with-5x-Faster-Streaming-in-Cassandra-4.adoc
@@ -16,7 +16,7 @@ As part of this replacement operation, the new Cassandra node streams data from 
 
 == Increasing Availability
 
-To minimize the failure window, we want to make these operations as fast as possible. The faster the new node completes streaming its data, the faster it can serve traffic, increasing the availability of the cluster. Towards this goal, Cassandra 4.0 saw the addition of https://en.wikipedia.org/wiki/Zero-copy[Zero Copy,window=_blank] streaming. For more details on Cassandra’s zero copy implementation, see this xref:blog/faster_streaming_in_cassandra.adoc[blog post,window=_blank] and https://issues.apache.org/jira/browse/CASSANDRA-14556[CASSANDRA-14556,window=_blank] for more information.
+To minimize the failure window, we want to make these operations as fast as possible. The faster the new node completes streaming its data, the faster it can serve traffic, increasing the availability of the cluster. Towards this goal, Cassandra 4.0 saw the addition of https://en.wikipedia.org/wiki/Zero-copy[Zero Copy,window=_blank] streaming. For more details on Cassandra’s zero copy implementation, see this xref:blog/Hardware-bound-Zero-Copy-Streaming-in-Apache-Cassandra-4.adoc[blog post,window=_blank] and https://issues.apache.org/jira/browse/CASSANDRA-14556[CASSANDRA-14556,window=_blank] for more information.
 
 == Talking Numbers
 

--- a/site-content/source/modules/ROOT/pages/development/gettingstarted.adoc
+++ b/site-content/source/modules/ROOT/pages/development/gettingstarted.adoc
@@ -56,7 +56,7 @@ reliably reproduce an issue can be a massive contribution.
 Document your method of reproduction in a JIRA comment or,
 better yet, produce an automated test that reproduces the issue and
 attach it to the ticket.
-If you go as far as producing a fix, follow the process for submitting a xref::patches.adoc[patch].
+If you go as far as producing a fix, follow the process for submitting a xref:development/patches.adoc[patch].
 
 To create a JIRA account, please request it on xref:community.adoc#discussions[the #cassandra or #cassandra-dev channels on ASF Slack], or on xref:community.adoc#discussions[the user or dev mailing list].
 

--- a/site-content/source/modules/ROOT/pages/development/ide.adoc
+++ b/site-content/source/modules/ROOT/pages/development/ide.adoc
@@ -189,7 +189,7 @@ Tests can be debugged by defining breakpoints (double-click line number) and
 selecting `Debug As > JUnit Test`.
 
 Alternatively all unit tests can be run from the command line as
-described in xref::testing.adoc[testing].
+described in xref:development/testing.adoc[testing].
 
 ==== Debugging Cassandra Using Eclipse
 

--- a/site-content/source/modules/ROOT/pages/development/index.adoc
+++ b/site-content/source/modules/ROOT/pages/development/index.adoc
@@ -13,24 +13,24 @@
 * xref:development/documentation.adoc[Documentation]
 * xref:development/release_process.adoc[Release process]
 
-include::page$development/gettingstarted.adoc[]
+include::page$development/gettingstarted.adoc[leveloffset=+1]
 
-include::page$development/ide.adoc[]
+include::page$development/ide.adoc[leveloffset=+1]
 
-include::page$development/testing.adoc[]
+include::page$development/testing.adoc[leveloffset=+1]
 
-include::page$development/code_style.adoc[]
+include::page$development/code_style.adoc[leveloffset=+1]
 
-include::page$development/how_to_commit.adoc[]
+include::page$development/how_to_commit.adoc[leveloffset=+1]
 
-include::page$development/how_to_review.adoc[]
+include::page$development/how_to_review.adoc[leveloffset=+1]
 
-include::page$development/patches.adoc[]
+include::page$development/patches.adoc[leveloffset=+1]
 
-include::page$development/ci.adoc[]
+include::page$development/ci.adoc[leveloffset=+1]
 
-include::page$development/dependencies.adoc[]
+include::page$development/dependencies.adoc[leveloffset=+1]
 
-include::page$development/documentation.adoc[Documentation]
+include::page$development/documentation.adoc[leveloffset=+1]
 
-include::page$development/release_process.adoc[]
+include::page$development/release_process.adoc[leveloffset=+1]

--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -182,7 +182,7 @@ https://repo.maven.apache.org/maven2/org/apache/cassandra/[Maven Central,window=
 
 [CAUTION]
 ====
-image:/assets/img/caution.svg[alt="Caution",width=64,height=64]  Debian and RedHat package repositories have moved!
+image:caution.svg[alt="Caution",width=64,height=64]  Debian and RedHat package repositories have moved!
 
 Debian's `sources.list` and RedHat's `cassandra.repo` files must be updated to point to the new repository URLs (see below).
 ====

--- a/site-content/source/modules/ROOT/pages/glossary.adoc
+++ b/site-content/source/modules/ROOT/pages/glossary.adoc
@@ -251,10 +251,6 @@ include::ROOT:partial$partition-summary.adoc[]
 
 include::ROOT:partial$partitioner.adoc[]
 
-include::ROOT:partial$persistent-volume.adoc[]
-
-include::ROOT:partial$persistent-volume-claim.adoc[]
-
 include::ROOT:partial$primary-key.adoc[]
 
 :leveloffset: -2
@@ -294,8 +290,6 @@ include::ROOT:partial$alphabet-nav.adoc[]
 :leveloffset: +2
 
 include::ROOT:partial$seed.adoc[]
-
-include::ROOT:partial$segment.adoc[]
 
 include::ROOT:partial$serializable-consistency.adoc[]
 


### PR DESCRIPTION
This is the start of a few PRs to retire the pile of technical debt we have, going back to Cassandra 4 with broken links. 

Two-commit fix for 19 broken Antora references in cassandra-website's own content. A separate PR will land on the in-tree docs after this passes staging. Together, the two PRs retire the broken-link tech debt that has been showing up in the Jenkins build's error-level log.

JIRA: https://issues.apache.org/jira/browse/CASSANDRA-21342