### PR TITLE
Fix obsolete git host name

### DIFF
--- a/site-content/source/modules/ROOT/pages/development/release_process.adoc
+++ b/site-content/source/modules/ROOT/pages/development/release_process.adoc
@@ -33,9 +33,9 @@ http://pgp.mit.edu/[MIT Keyserver]. Some `gpg` clients are publishing the keys h
 welcome to set the server where the keys will be published by following https://keys.openpgp.org/about/usage[this guide].
 
 Once completed, you need to create a ticket https://issues.apache.org/jira/browse/CASSANDRA-18205[like this] 
-and ask a PMC to add your key to `KEYS` file.
+and ask a PMC member to add your key to `KEYS` file.
 
-A PMC will include your public key to this file:
+The PMC member will include your public key to this file:
 
 [source,none]
 ----
@@ -200,8 +200,8 @@ The distribution packages are available here: https://dist.apache.org/repos/dist
 
 The vote will be open for 72 hours (longer if needed).
 
-[1]: (CHANGES.txt) https://git1-us-west.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=<version>-tentative
-[2]: (NEWS.txt) https://git1-us-west.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=NEWS.txt;hb=<version>-tentative
+[1]: (CHANGES.txt) https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=<version>-tentative
+[2]: (NEWS.txt) https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=NEWS.txt;hb=<version>-tentative
 ----
 
 === Post-vote operations
@@ -302,8 +302,8 @@ were to encounter any problem.
 
 Enjoy!
 
-[1]: (CHANGES.txt) https://git1-us-west.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=<version>
-[2]: (NEWS.txt) https://git1-us-west.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=NEWS.txt;hb=<version>
+[1]: (CHANGES.txt) https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=CHANGES.txt;hb=<version>
+[2]: (NEWS.txt) https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=NEWS.txt;hb=<version>
 [3]: https://issues.apache.org/jira/browse/CASSANDRA
 ----
 


### PR DESCRIPTION
Also, 'PMC' refers to a group of people, not a person.