### PR TITLE
Bump Python driver version to 3.30.1

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -1,6 +1,10 @@
 = Downloading Cassandra
 :page-layout: basic-full
 
+:java-driver-4x-version: 4.19.3
+:go-driver-version: 2.1.2
+:python-driver-version: 3.30.1
+:nodejs-driver-version: 4.9.0
 
 [openblock,arrow py-xlarge]
 ----
@@ -93,9 +97,9 @@ https://www.apache.org/dyn/closer.lua/cassandra/4.0.20/apache-cassandra-4.0.20-b
 ==== Latest release on 2026-06-01
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/4.19.3/apache-cassandra-java-driver-4.19.3-source.tar.gz[4.19.3 (source),window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-java-driver/{java-driver-4x-version}/apache-cassandra-java-driver-{java-driver-4x-version}-source.tar.gz[{java-driver-4x-version} (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.3/apache-cassandra-java-driver-4.19.3-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.3/apache-cassandra-java-driver-4.19.3-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/4.19.3/apache-cassandra-java-driver-4.19.3-source.tar.gz.sha512[sha512,window=blank])
+(https://downloads.apache.org/cassandra/cassandra-java-driver/{java-driver-4x-version}/apache-cassandra-java-driver-{java-driver-4x-version}-source.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/{java-driver-4x-version}/apache-cassandra-java-driver-{java-driver-4x-version}-source.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-java-driver/{java-driver-4x-version}/apache-cassandra-java-driver-{java-driver-4x-version}-source.tar.gz.sha512[sha512,window=blank])
 
 Java drivers for Cassandra are also available on
 https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Maven Central,window=blank].
@@ -113,9 +117,9 @@ https://central.sonatype.com/artifact/org.apache.cassandra/java-driver-core[Mave
 ==== Latest release on 2026-06-16
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/2.1.2/apache-cassandra-gocql-driver-2.1.2.tar.gz[2.1.2 (source),window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-gocql-driver/{go-driver-version}/apache-cassandra-gocql-driver-{go-driver-version}.tar.gz[{go-driver-version} (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.2/apache-cassandra-gocql-driver-2.1.2.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.2/apache-cassandra-gocql-driver-2.1.2.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/2.1.2/apache-cassandra-gocql-driver-2.1.2.tar.gz.sha512[sha512,window=blank]) +
+(https://downloads.apache.org/cassandra/cassandra-gocql-driver/{go-driver-version}/apache-cassandra-gocql-driver-{go-driver-version}.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/{go-driver-version}/apache-cassandra-gocql-driver-{go-driver-version}.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-gocql-driver/{go-driver-version}/apache-cassandra-gocql-driver-{go-driver-version}.tar.gz.sha512[sha512,window=blank]) +
 
 GoCQL driver for Cassandra is also available on https://github.com/apache/cassandra-gocql-driver[Github,window=blank].
 
@@ -129,12 +133,12 @@ GoCQL driver for Cassandra is also available on https://github.com/apache/cassan
 [discrete]
 ==== Apache Cassandra Python Driver
 [discrete]
-==== Latest release on 2026-04-02
+==== Latest release on 2026-07-06
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-python-driver/3.30.0/cassandra_driver-3.30.0.tar.gz[3.30.0 (source),window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-python-driver/{python-driver-version}/cassandra_driver-{python-driver-version}.tar.gz[{python-driver-version} (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-python-driver/3.30.0/cassandra_driver-3.30.0.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-python-driver/3.30.0/cassandra_driver-3.30.0.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-python-driver/3.30.0/cassandra_driver-3.30.0.tar.gz.sha512[sha512,window=blank])
+(https://downloads.apache.org/cassandra/cassandra-python-driver/{python-driver-version}/cassandra_driver-{python-driver-version}.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-python-driver/{python-driver-version}/cassandra_driver-{python-driver-version}.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-python-driver/{python-driver-version}/cassandra_driver-{python-driver-version}.tar.gz.sha512[sha512,window=blank])
 
 Python drivers for Cassandra are also available on
 https://pypi.org/project/cassandra-driver/[PyPI,window=blank].
@@ -152,9 +156,9 @@ https://pypi.org/project/cassandra-driver/[PyPI,window=blank].
 ==== Latest release on 2026-04-24
 
 [.btn.btn--alt]
-https://www.apache.org/dyn/closer.lua/cassandra/cassandra-nodejs-driver/4.9.0/apache-cassandra-nodejs-driver-4.9.0-src.tar.gz[4.9.0 (source),window=blank]
+https://www.apache.org/dyn/closer.lua/cassandra/cassandra-nodejs-driver/{nodejs-driver-version}/apache-cassandra-nodejs-driver-{nodejs-driver-version}-src.tar.gz[{nodejs-driver-version} (source),window=blank]
 
-(https://downloads.apache.org/cassandra/cassandra-nodejs-driver/4.9.0/apache-cassandra-nodejs-driver-4.9.0-src.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-nodejs-driver/4.9.0/apache-cassandra-nodejs-driver-4.9.0-src.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-nodejs-driver/4.9.0/apache-cassandra-nodejs-driver-4.9.0-src.tar.gz.sha512[sha512,window=blank])
+(https://downloads.apache.org/cassandra/cassandra-nodejs-driver/{nodejs-driver-version}/apache-cassandra-nodejs-driver-{nodejs-driver-version}-src.tar.gz.asc[pgp,window=blank], https://downloads.apache.org/cassandra/cassandra-nodejs-driver/{nodejs-driver-version}/apache-cassandra-nodejs-driver-{nodejs-driver-version}-src.tar.gz.sha256[sha256,window=blank], https://downloads.apache.org/cassandra/cassandra-nodejs-driver/{nodejs-driver-version}/apache-cassandra-nodejs-driver-{nodejs-driver-version}-src.tar.gz.sha512[sha512,window=blank])
 
 node.js drivers for Cassandra are also available on
 https://www.npmjs.com/package/cassandra-driver[npm,window=blank].


### PR DESCRIPTION
Verified all links work as expected

<img width="1350" height="596" alt="python-3301-update" src="https://github.com/user-attachments/assets/0dbd376d-6aa7-4c96-a0a9-0c9f37aacaa6" />
