### PR TITLE
Update landing page for Apache Cassandra 5.0 release

### DIFF
--- a/site-content/source/modules/ROOT/pages/Apache-Cassandra-5.0-Moving-Toward-an-AI-Driven-Future.adoc
+++ b/site-content/source/modules/ROOT/pages/Apache-Cassandra-5.0-Moving-Toward-an-AI-Driven-Future.adoc
@@ -4,9 +4,9 @@
 :page-role: bugs
 :description: landing page for 5.0
 
-=== Cassandra 5.0 is coming soon!
+=== Cassandra 5.0 is here!
 
-We are excited about the upcoming availability of Apache Cassandra 5.0, the project’s major release for 2023! With a focus on machine learning and artificial intelligence, this release brings a host of exciting features and enhancements that empower you to take your data-driven applications to the next level.
+Apache Cassandra 5.0 delivers a host of features and enhancements focused on machine learning and artificial intelligence, empowering you to take your data-driven applications to the next level.
 
 *Here’s an overview of some of the release’s major features:*
 


### PR DESCRIPTION
Update Cassandra 5.0 landing page from pre-release to released language

The 5.0 landing page still described the release as "coming soon" and referred to it as "the project's major release for 2023." I thisk this is a little bit missleading for new people. Cassandra 5.0 was released in September 2024, so this copy is out of date. 

Update the intro to present tense to reflect that 5.0 is now available. No feature content or links changed.