### PR TITLE
Update release series to 50x in download.adoc

### DIFF
--- a/site-content/source/modules/ROOT/pages/download.adoc
+++ b/site-content/source/modules/ROOT/pages/download.adoc
@@ -238,8 +238,8 @@ Debian's `sources.list` and RedHat's `cassandra.repo` files must be updated to p
 === Installation from Debian packages
 
 * For the `<release series>` specify the major version number, without dot, and with an appended x.
-* The latest `<release series>` is `41x`.
-* For older releases, the `<release series>` can be one of `40x`, `311`, `30x`, or `22x`.
+* The latest `<release series>` is `50x`.
+* For older releases, the `<release series>` can be one of `41x`,`40x`, `311`, `30x`, or `22x`.
 * Add the Apache Cassandra repository keys:
 
 [source]
@@ -247,11 +247,11 @@ Debian's `sources.list` and RedHat's `cassandra.repo` files must be updated to p
 curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
 --
 
-* Add the Apache repository of Cassandra to `/etc/apt/sources.list.d/cassandra.sources.list`, for example for the latest 4.1
+* Add the Apache repository of Cassandra to `/etc/apt/sources.list.d/cassandra.sources.list`, for example for the latest 5.0
 
 [source]
 --
-echo "deb [signed-by=/etc/apt/keyrings/apache-cassandra.asc] https://debian.cassandra.apache.org 41x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+echo "deb [signed-by=/etc/apt/keyrings/apache-cassandra.asc] https://debian.cassandra.apache.org 50x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
 --
 
 * Update the repositories:
@@ -288,8 +288,8 @@ sudo apt-get update
 === Installation from RPM packages
 
 * For the `<release series>``` specify the major version number, without dot, and with an appended x.
-* The latest `<release series>` is `41x`.
-* For older releases, the `<release series>` can be one of `311x`, `30x`, or `22x`.
+* The latest `<release series>` is `50x`.
+* For older releases, the `<release series>` can be one of `41x`, `311x`, `30x`, or `22x`.
 * (Not all versions of Apache Cassandra are available, since building RPMs is a recent addition to the project.)
 * For CentOS 7 and similar (rpm < 4.14), append the `noboolean` repository
 * Add the Apache repository of Cassandra to `/etc/yum.repos.d/cassandra.repo`, for example for the latest 4.0 version:
@@ -299,7 +299,7 @@ sudo apt-get update
 --
 [cassandra]
 name=Apache Cassandra
-baseurl=https://redhat.cassandra.apache.org/41x/
+baseurl=https://redhat.cassandra.apache.org/50x/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://downloads.apache.org/cassandra/KEYS
@@ -311,7 +311,7 @@ Or for CentOS 7:
 --
 [cassandra]
 name=Apache Cassandra
-baseurl=https://redhat.cassandra.apache.org/41x/noboolean/
+baseurl=https://redhat.cassandra.apache.org/50x/noboolean/
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://downloads.apache.org/cassandra/KEYS


### PR DESCRIPTION
Update the package installation documentation to use Apache Cassandra 5.0 as the latest release series.

Changes
Change the latest release series from 41x to 50x.
Add 41x to the list of older supported release series.
Update the Debian repository example from 41x to 50x.
Update the RPM repository examples from 41x to 50x.
Update the corresponding text from Cassandra 4.1/4.0 to Cassandra 5.0.