### PR TITLE
Self-host MathJax so stem/latexmath renders under the site CSP

### DIFF
--- a/site-content/docker-entrypoint.sh
+++ b/site-content/docker-entrypoint.sh
@@ -316,12 +316,12 @@ run_preview_mode() {
   export -f render_site_content_to_html
 
   local on_change_functions="render_site_content_to_html"
-  local find_paths="${CASSANDRA_WEBSITE_DIR}/${ANTORA_CONTENT_SOURCES_CASSANDRA_WEBSITE_START_PATH}"
+  local find_paths=("${CASSANDRA_WEBSITE_DIR}/${ANTORA_CONTENT_SOURCES_CASSANDRA_WEBSITE_START_PATH}")
 
   if [ "${COMMAND_GENERATE_DOCS}" = "run" ]
   then
     on_change_functions="generate_cassandra_versioned_docs && ${on_change_functions}"
-    find_paths="${find_paths} ${CASSANDRA_WORKING_DIR}/${ANTORA_CONTENT_SOURCES_CASSANDRA_START_PATH}"
+    find_paths+=("${CASSANDRA_WORKING_DIR}/${ANTORA_CONTENT_SOURCES_CASSANDRA_START_PATH}")
 
     export -f generate_cassandra_versioned_docs
 
@@ -345,7 +345,9 @@ run_preview_mode() {
   live-server --port=5151 --host=0.0.0.0 --no-browser --no-css-inject --wait=2000 &
   popd > /dev/null
 
-  find "${find_paths}" -type f | entr /bin/bash -c "${on_change_functions}"
+  # -n keeps entr out of interactive mode; run.sh does not allocate a TTY, so
+  # without it entr aborts with "unable to get terminal attributes"
+  find "${find_paths[@]}" -type f | entr -n /bin/bash -c "${on_change_functions}"
 }
 
 

--- a/site-ui/Dockerfile
+++ b/site-ui/Dockerfile
@@ -36,10 +36,14 @@ RUN apt-get update && \
         git \
         vim
 
-ENV NODE_PACKAGE="node-${NODE_VERSION_ARG}-linux-x64.tar.gz"
-RUN wget https://nodejs.org/download/release/${NODE_VERSION_ARG}/${NODE_PACKAGE} && \
-    tar -C /usr/local --strip-components 1 -xzf ${NODE_PACKAGE} && \
-    rm ${NODE_PACKAGE}
+RUN sh -c '\
+  set -ex ;\
+  NODE_PLATFORM=x64 ;\
+  [ $(uname -m) = "aarch64" ] && NODE_PLATFORM=arm64 ;\
+  NODE_PACKAGE="node-'"${NODE_VERSION_ARG}"'-linux-${NODE_PLATFORM}.tar.gz" ;\
+  wget -q https://nodejs.org/download/release/'"${NODE_VERSION_ARG}"'/${NODE_PACKAGE} ;\
+  tar -C /usr/local --strip-components 1 -xzf ${NODE_PACKAGE} ;\
+  rm ${NODE_PACKAGE}'
 
 RUN npm install -g npm@11.6.0
 RUN npm install -g gulp-cli@3.1.0

--- a/site-ui/gulp.d/tasks/build.js
+++ b/site-ui/gulp.d/tasks/build.js
@@ -92,6 +92,7 @@ module.exports = (src, dest, preview) => () => {
       .pipe(buffer())
       .pipe(uglify()),
     vfs.src(require.resolve('jquery/dist/jquery.min.js'), opts).pipe(concat('js/vendor/jquery.js')),
+    vfs.src(require.resolve('mathjax/es5/tex-svg-full.js'), opts).pipe(concat('js/vendor/mathjax.js')),
     vfs
       .src(['css/site.css', 'css/vendor/docsearch.css'], { ...opts, sourcemaps })
       .pipe(postcss((file) => ({ plugins: postcssPlugins, options: { file } }))),

--- a/site-ui/package.json
+++ b/site-ui/package.json
@@ -44,6 +44,7 @@
     "jquery": "~3.5.1",
     "js-yaml": "~3.14",
     "mark.js": "~8.11",
+    "mathjax": "~3.2",
     "merge-stream": "~2.0",
     "postcss-calc": "~7.0",
     "postcss-custom-properties": "~9.1",

--- a/site-ui/src/partials/footer-scripts.hbs
+++ b/site-ui/src/partials/footer-scripts.hbs
@@ -15,23 +15,18 @@
 {{/if}}
 {{#with (resolvePage page.relativeSrcPath model=false)}}
     {{#unless (eq asciidoc.attributes.stem undefined)}}
-<script type="text/x-mathjax-config">
-MathJax.Hub.Config({
-  messageStyle: "none",
-  tex2jax: { inlineMath: [["\\(", "\\)"]], displayMath: [["\\[", "\\]"]], ignoreClass: "nostem|nolatexmath" },
-  asciimath2jax: { delimiters: [["\\$", "\\$"]], ignoreClass: "nostem|noasciimath" },
-  TeX: { equationNumbers: { autoNumber: "none" } }
-})
-MathJax.Hub.Register.StartupHook("AsciiMath Jax Ready", function () {
-  MathJax.InputJax.AsciiMath.postfilterHooks.Add(function (data, node) {
-    if ((node = data.script.parentNode) && (node = node.parentNode) && node.classList.contains("stemblock")) {
-      data.math.root.display = "block"
-    }
-    return data
-  })
-})
+<script>
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    tags: "none",
+  },
+  options: { ignoreHtmlClass: "nostem|nolatexmath" },
+  startup: { typeset: true },
+}
 </script>
-<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+<script async src="{{{@root.uiRootPath}}}/js/vendor/mathjax.js"></script>
     {{/unless}}
 {{/with}}
 <script>

--- a/site-ui/src/partials/header-scripts.hbs
+++ b/site-ui/src/partials/header-scripts.hbs
@@ -1,4 +1,3 @@
 {{#with site.keys.googleAnalytics}}
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{{this}}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {{/with}}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>


### PR DESCRIPTION
(I used AI for this).

The cassandra website has been broken for a while now, rendering raw latex in the docs.

The docs pages loaded MathJax 2.7.9 from cdnjs.cloudflare.com, but cassandra.apache.org sends a Content-Security-Policy whose script-src allows only 'self' and a few apache.org hosts. Chrome blocks the script, so no math is ever typeset and pages fall back to showing the raw LaTeX source, e.g. `The target sstable size \(s_{t}\)` on [managing/operating/compaction/ucs.html](https://cassandra.apache.org/doc/stable/cassandra/managing/operating/compaction/ucs.html).

Pull MathJax from npm into the UI bundle instead, mirroring how jquery is already vendored in build.js. es5/tex-svg-full.js is used because it is fully self-contained: the SVG output has the font glyph data compiled in, so it makes no further network requests and needs no font directory. Serving it from the bundle keeps it within script-src 'self'.

Config is updated to the MathJax 3 API. The AsciiMath startup hook is dropped along with it; the Cassandra docs only use :stem: latexmath.

Also drop the jQuery tag in header-scripts.hbs, which had the same problem: it loaded from ajax.googleapis.com, which script-src does not allow either, so the request was blocked on every docs page load. It was redundant as well - head-scripts.hbs already loads the bundled js/vendor/jquery.js earlier in the head, which is why jQuery kept working despite the block.