### PR TITLE
Add LibreDB Studio to ecosystem documentation

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -138,6 +138,8 @@ https://github.com/thelastpickle/cassandra-medusa[The Last Pickle Medusa,window=
 
 https://github.com/thelastpickle/cassandra-reaper[The Last Pickle Reaper,window=blank]: Automated repair tool for Apache Cassandra (DataStax)
 
+https://libredb.org/[LibreDB Studio,window=blank]: LibreDB Studio is an MIT licensed SQL IDE that runs in a browser and is deployed next to the database instead of installed on a workstation, shipping as a container, a Helm chart, an OpenShift operator, or an npm package embedded in another application. It connects to Cassandra over the native CQL protocol through cassandra-driver, a pure JavaScript client with no native module to install, reading the schema tree straight from system_schema. Row counts, table sizes and query plans are left out rather than estimated, since Cassandra has no honest way to produce any of the three.
+
 https://github.com/tjake/Solandra[Lucandra/Solandra,window=blank]: https://github.com/tjake/Solandra
 
 https://nifi.apache.org/[NiFi,window=blank]: Apache NiFi supports powerful and scalable directed graphs of data routing, transformation, and system mediation logic.


### PR DESCRIPTION
Added a new entry for LibreDB Studio, an open source SQL IDE that connects to Cassandra over the native CQL protocol via cassandra-driver.