### PR TITLE
Add Beekeeper Studio to ecosystem page

### DIFF
--- a/site-content/source/modules/ROOT/pages/ecosystem.adoc
+++ b/site-content/source/modules/ROOT/pages/ecosystem.adoc
@@ -70,6 +70,8 @@ https://axonops.com/workbench[AxonOps Workbench^]: Open Source Desktop Client fo
 
 https://github.com/Azure-Samples/cassandra-proxy[Azure-Samples/Cassandra Proxy,window=blank]: This proxy handles client connections and forwards them to two Cassandra clusters simultaneously.
 
+https://www.beekeeperstudio.io/[Beekeeper Studio,window=blank]: A modern, easy-to-use SQL client and database manager with support for Cassandra and many other databases. Free and open-source, with a friendly UI for browsing data, running CQL queries, and managing connections across Windows, macOS, and Linux.
+
 https://cassandra.tools/[Cassandra.Tools,window=blank]: Curated site with top open-source tools for Cassandra.
 
 https://github.com/instaclustr/cassandra-lucene-index[Cassandra Lucene Index,window=blank]: This is a plugin for Apache Cassandra that extends its index functionality to provide near real time search such as ElasticSearch or Solr, including full text search capabilities and free multivariable, geospatial and bitemporal search


### PR DESCRIPTION
Adds Beekeeper Studio (beekeeperstudio.io), a free and open-source SQL client with Cassandra support, under the Cassandra Tools section.