### PR TITLE
Add LibreDB Studio to Cassandra tools

### DIFF
--- a/site-content/source/modules/ROOT/pages/third-party.adoc
+++ b/site-content/source/modules/ROOT/pages/third-party.adoc
@@ -51,6 +51,7 @@ Cassandra metrics along with diagnostic events to facilitate problem
 resolution and remediation
 * https://hackolade.com/nosqldb.html#cassandra[Hackolade]: Visual data
 modeling tool for Cassandra
+* https://github.com/libredb/libredb-studio[LibreDB Studio]: Open source, self-hosted, browser-based database IDE with a CQL editor and object browser for Cassandra, plus a read-only AI assistant that can run on a local model. MIT licensed.
 * https://github.com/thelastpickle/cassandra-medusa[The Last Pickle
 Medusa]: Apache Cassandra Backup and Restore Tool (DataStax)
 * https://github.com/thelastpickle/cassandra-reaper[The Last Pickle


### PR DESCRIPTION
Adding LibreDB Studio under Third-party projects > Cassandra tools.

LibreDB Studio is an open-source (MIT), self-hosted, browser-based database IDE. It connects to Cassandra (CQL editor and object browser) alongside 13 other engines, and includes a read-only AI assistant that can run on a local model, so data stays in your network.

Disclosure: I am part of the LibreDB Studio team.

Repo: https://github.com/libredb/libredb-studio
